### PR TITLE
feat(website): add transcript trim, recording button size, and refresh settings

### DIFF
--- a/.changeset/settings-ui-improvements.md
+++ b/.changeset/settings-ui-improvements.md
@@ -1,0 +1,5 @@
+---
+"website": patch
+---
+
+Add more settings and make the settings sheet scrollable: a "Transcript history" option to show all transcripts or trim the feed to the latest 10 (waiting for the auto-scroll to settle before pruning old bubbles so nothing pops out mid-animation), a "Recording button" size option (default / small / hidden), and a "Refresh app" button that reloads the page.

--- a/apps/website/src/components/MessageFeed.test.ts
+++ b/apps/website/src/components/MessageFeed.test.ts
@@ -5,6 +5,7 @@ import {
   getMessageFeedScrollBehavior,
   MESSAGE_CARD_ACTION_WIDTH,
   MESSAGE_CARD_SNAP_TOLERANCE,
+  selectVisibleMessages,
 } from "./messageFeedScroll.ts";
 
 test("uses instant scrolling for the initial message load", () => {
@@ -56,5 +57,28 @@ describe("message card snap helpers", () => {
     expect(getMessageCardSnapAction(189, 100, 10)).toBeNull();
     expect(getMessageCardSnapAction(190, 100, 10)).toBe("swipe-left");
     expect(getMessageCardInitialScrollLeft(100)).toBe(100);
+  });
+});
+
+describe("selectVisibleMessages", () => {
+  const items = Array.from({ length: 15 }, (_, i) => i);
+
+  test("keeps every message when the limit is null", () => {
+    expect(selectVisibleMessages(items, null)).toEqual(items);
+  });
+
+  test("keeps only the newest messages when a limit is set", () => {
+    expect(selectVisibleMessages(items, 10)).toEqual([5, 6, 7, 8, 9, 10, 11, 12, 13, 14]);
+  });
+
+  test("returns everything when there are fewer messages than the limit", () => {
+    expect(selectVisibleMessages([1, 2, 3], 10)).toEqual([1, 2, 3]);
+  });
+
+  test("does not mutate the input array", () => {
+    const original = [1, 2, 3, 4];
+    const result = selectVisibleMessages(original, 2);
+    expect(result).toEqual([3, 4]);
+    expect(original).toEqual([1, 2, 3, 4]);
   });
 });

--- a/apps/website/src/components/MessageFeed.tsx
+++ b/apps/website/src/components/MessageFeed.tsx
@@ -6,7 +6,9 @@ import {
   $lastSwipedMessage,
   $messages,
   $sessionToken,
+  $transcriptListMode,
   markPendingLocalSwipe,
+  TRANSCRIPT_LIST_LIMIT,
   type Message,
 } from "../store.ts";
 import { $retainedRecordings } from "../recordedAudio.ts";
@@ -17,6 +19,8 @@ import {
   getMessageFeedScrollBehavior,
   MESSAGE_CARD_ACTION_WIDTH,
   MESSAGE_CARD_SNAP_TOLERANCE,
+  MESSAGE_FEED_PRUNE_FALLBACK_MS,
+  selectVisibleMessages,
 } from "./messageFeedScroll.ts";
 
 const SWIPE_GLOW_DURATION_MS = 900;
@@ -527,11 +531,43 @@ export function MessageFeed({ onOpenSettings }: MessageFeedProps = {}) {
   const retainedRecordings = useStore($retainedRecordings);
   const authToken = useStore($sessionToken);
   const backendUrl = useStore($backendUrl);
+  const transcriptListMode = useStore($transcriptListMode);
   const [evalMessageId, setEvalMessageId] = useState<string | null>(null);
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
   const bottomRef = useRef<HTMLDivElement>(null);
   const hasScrolledInitiallyRef = useRef(false);
+  // Ids committed to the DOM on the previous render, and a mirror of the ids
+  // we are currently keeping mounted past the trim — both read from effects.
+  const prevDisplayedRef = useRef<string[]>([]);
+  const retainedIdsRef = useRef<string[]>([]);
 
-  const messages = Array.from(messagesMap.values()).sort((a, b) => a.createdAt - b.createdAt);
+  const sorted = Array.from(messagesMap.values()).sort((a, b) => a.createdAt - b.createdAt);
+  const limit = transcriptListMode === "latest" ? TRANSCRIPT_LIST_LIMIT : null;
+  const target = selectVisibleMessages(sorted, limit);
+
+  // When the message set or the trim mode changes, hold onto whatever was on
+  // screen a moment ago so trimmed bubbles do not pop out before we have
+  // scrolled. Updating state during render keeps this flicker-free — React
+  // re-renders with the retained ids before the browser paints.
+  const [snapshot, setSnapshot] = useState<{
+    map: Map<string, Message>;
+    mode: string;
+    retainedIds: string[];
+  }>(() => ({ map: messagesMap, mode: transcriptListMode, retainedIds: [] }));
+  if (snapshot.map !== messagesMap || snapshot.mode !== transcriptListMode) {
+    setSnapshot({
+      map: messagesMap,
+      mode: transcriptListMode,
+      retainedIds:
+        limit === null ? [] : prevDisplayedRef.current.filter((id) => messagesMap.has(id)),
+    });
+  }
+
+  const keptIds = new Set(target.map((m) => m.id));
+  for (const id of snapshot.retainedIds) keptIds.add(id);
+  const messages = limit === null ? sorted : sorted.filter((m) => keptIds.has(m.id));
+  retainedIdsRef.current = messages.length > target.length ? snapshot.retainedIds : [];
+
   const evalMessage = evalMessageId ? messagesMap.get(evalMessageId) : undefined;
 
   const canEval = (message: Message): boolean =>
@@ -540,14 +576,41 @@ export function MessageFeed({ onOpenSettings }: MessageFeedProps = {}) {
     !!retainedRecordings.get(message.referenceId)?.chunks.length;
 
   useEffect(() => {
-    if (messages.length === 0) return;
-    bottomRef.current?.scrollIntoView({
-      behavior: getMessageFeedScrollBehavior(hasScrolledInitiallyRef.current),
-    });
-    hasScrolledInitiallyRef.current = true;
-  }, [messages]);
+    prevDisplayedRef.current = messages.map((m) => m.id);
+  });
 
-  if (messages.length === 0) {
+  useEffect(() => {
+    if (sorted.length === 0) return;
+    const behavior = getMessageFeedScrollBehavior(hasScrolledInitiallyRef.current);
+    bottomRef.current?.scrollIntoView({ behavior });
+    hasScrolledInitiallyRef.current = true;
+
+    // Nothing is being held past the trim, so there is nothing to prune.
+    if (retainedIdsRef.current.length === 0) return;
+
+    // Drop the retained bubbles only once the scroll has come to rest, so they
+    // leave the DOM without yanking the viewport mid-animation. `scrollend`
+    // covers the smooth scroll; the timeout covers the case where the feed was
+    // already at the bottom and no scroll (hence no `scrollend`) ever happens.
+    const container = scrollContainerRef.current;
+    let settled = false;
+    const prune = () => {
+      if (settled) return;
+      settled = true;
+      container?.removeEventListener("scrollend", prune);
+      window.clearTimeout(fallback);
+      setSnapshot((s) => (s.retainedIds.length === 0 ? s : { ...s, retainedIds: [] }));
+    };
+    const fallback = window.setTimeout(prune, MESSAGE_FEED_PRUNE_FALLBACK_MS);
+    container?.addEventListener("scrollend", prune);
+    return () => {
+      settled = true;
+      container?.removeEventListener("scrollend", prune);
+      window.clearTimeout(fallback);
+    };
+  }, [messagesMap, transcriptListMode]);
+
+  if (sorted.length === 0) {
     return (
       <div className="flex-1 flex items-center justify-center">
         <div className="flex flex-col items-center gap-3 px-6 text-center">
@@ -571,7 +634,7 @@ export function MessageFeed({ onOpenSettings }: MessageFeedProps = {}) {
   }
 
   return (
-    <div className="flex-1 overflow-y-auto py-1">
+    <div ref={scrollContainerRef} className="flex-1 overflow-y-auto py-1">
       <div className="h-[50vh]" />
       {messages.map((msg) => (
         <MessageCard

--- a/apps/website/src/components/RecordingBar.tsx
+++ b/apps/website/src/components/RecordingBar.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { useStore } from "@nanostores/react";
 import {
   $audioProcessingMode,
+  $recordingButtonSize,
   $sessionToken,
   $backendUrl,
   $wakeLockMode,
@@ -25,6 +26,7 @@ export function RecordingBar({
   const backendUrl = useStore($backendUrl);
   const audioProcessingMode = useStore($audioProcessingMode);
   const wakeLockMode = useStore($wakeLockMode);
+  const recordingButtonSize = useStore($recordingButtonSize);
   const [isRecording, setIsRecording] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -242,10 +244,19 @@ export function RecordingBar({
 
   const canRecord = !!authToken;
 
+  // The button is hidden entirely for display-only use — the component stays
+  // mounted so an in-progress recording and the always-on wake lock keep going.
+  if (recordingButtonSize === "hidden") return null;
+
+  const isSmall = recordingButtonSize === "small";
+  const buttonBoxClass = isSmall ? "w-20 h-20" : "w-32 h-32";
+  const innerSizeClass = isSmall ? "w-7 h-7" : "w-10 h-10";
+  const settingsIconSize = isSmall ? 28 : 40;
+
   return (
     <div className="flex-none border-t border-(--m3-outline-variant) px-4 py-4">
       {error && <p className="text-xs text-(--m3-error) mb-2 text-center">{error}</p>}
-      <div className="relative h-32 flex items-center justify-center">
+      <div className={`relative flex items-center justify-center ${isSmall ? "h-24" : "h-32"}`}>
         <canvas
           ref={canvasRef}
           width={600}
@@ -255,23 +266,22 @@ export function RecordingBar({
         <button
           onClick={handleToggle}
           className={[
-            "relative z-10 w-32 h-32 rounded-full flex items-center justify-center transition-all shadow-lg",
+            "relative z-10 rounded-full flex items-center justify-center transition-all shadow-lg",
+            buttonBoxClass,
             isRecording
               ? "bg-red-500 scale-110 shadow-red-500/50"
-              : canRecord
-                ? "bg-(--m3-surface-container-high) hover:bg-(--m3-surface-container-highest) active:scale-95"
-                : "bg-(--m3-surface-container-high) hover:bg-(--m3-surface-container-highest) active:scale-95",
+              : "bg-(--m3-surface-container-high) hover:bg-(--m3-surface-container-highest) active:scale-95",
           ].join(" ")}
           aria-label={
             isRecording ? "Stop recording" : canRecord ? "Start recording" : "Open settings"
           }
         >
           {isRecording ? (
-            <span className="w-10 h-10 rounded-md bg-(--m3-on-error)" />
+            <span className={`${innerSizeClass} rounded-md bg-(--m3-on-error)`} />
           ) : canRecord ? (
-            <span className="w-10 h-10 rounded-full bg-red-500" />
+            <span className={`${innerSizeClass} rounded-full bg-red-500`} />
           ) : (
-            <SettingsIcon size={40} />
+            <SettingsIcon size={settingsIconSize} />
           )}
         </button>
       </div>

--- a/apps/website/src/components/SettingsSheet.test.tsx
+++ b/apps/website/src/components/SettingsSheet.test.tsx
@@ -27,6 +27,10 @@ test("web sign-in actions are disabled until the backend URL is filled", async (
   expect(markup).toContain("Audio Processing");
   expect(markup).toContain(">On<");
   expect(markup).toContain(">Off<");
+  expect(markup).toContain("Transcript history");
+  expect(markup).toContain("Latest 10 only");
+  expect(markup).toContain("Recording button");
+  expect(markup).toContain("Refresh app");
   expect(markup).toContain("Sign in with OIDC");
   expect(markup).toContain("Log in with another browser");
   expect(markup).toContain("disabled");

--- a/apps/website/src/components/SettingsSheet.tsx
+++ b/apps/website/src/components/SettingsSheet.tsx
@@ -4,7 +4,9 @@ import {
   $audioProcessingMode,
   $backendUrl,
   $desktopSwipeBehavior,
+  $recordingButtonSize,
   $sessionToken,
+  $transcriptListMode,
   $userInfo,
   $wakeLockMode,
   $wakeLockActive,
@@ -12,9 +14,13 @@ import {
   clearSessionToken,
   setAudioProcessingMode,
   setDesktopSwipeBehavior,
+  setRecordingButtonSize,
+  setTranscriptListMode,
   setWakeLockMode,
   saveSessionToken,
   type AudioProcessingMode,
+  type RecordingButtonSize,
+  type TranscriptListMode,
   type WakeLockMode,
 } from "../store.ts";
 import { startSignIn } from "../oidc.ts";
@@ -32,6 +38,8 @@ export function SettingsSheet({ open: controlledOpen, onOpenChange }: SettingsSh
   const backendUrl = useStore($backendUrl);
   const audioProcessingMode = useStore($audioProcessingMode);
   const desktopSwipeBehavior = useStore($desktopSwipeBehavior);
+  const transcriptListMode = useStore($transcriptListMode);
+  const recordingButtonSize = useStore($recordingButtonSize);
   const sessionToken = useStore($sessionToken);
   const userInfo = useStore($userInfo);
   const wakeLockMode = useStore($wakeLockMode);
@@ -74,7 +82,7 @@ export function SettingsSheet({ open: controlledOpen, onOpenChange }: SettingsSh
       onClick={() => setOpen(false)}
     >
       <div
-        className="bg-(--m3-surface-container-high) rounded-t-2xl px-4 pt-5 pb-10 space-y-5"
+        className="bg-(--m3-surface-container-high) rounded-t-2xl px-4 pt-5 pb-10 space-y-5 max-h-[85dvh] overflow-y-auto overscroll-contain"
         onClick={(e) => e.stopPropagation()}
       >
         <div className="flex items-center justify-between">
@@ -135,6 +143,35 @@ export function SettingsSheet({ open: controlledOpen, onOpenChange }: SettingsSh
           >
             <option value="on">On</option>
             <option value="off">Off</option>
+          </select>
+        </div>
+
+        <div className="space-y-1.5">
+          <span className="text-xs font-medium text-(--m3-on-surface-variant) uppercase tracking-wider">
+            Transcript history
+          </span>
+          <select
+            value={transcriptListMode}
+            onChange={(e) => setTranscriptListMode(e.target.value as TranscriptListMode)}
+            className="w-full bg-(--m3-surface-container-highest) rounded-xl px-3 py-2.5 text-sm focus:outline-none focus:ring-1 focus:ring-(--m3-outline) appearance-none"
+          >
+            <option value="all">Show all</option>
+            <option value="latest">Latest 10 only</option>
+          </select>
+        </div>
+
+        <div className="space-y-1.5">
+          <span className="text-xs font-medium text-(--m3-on-surface-variant) uppercase tracking-wider">
+            Recording button
+          </span>
+          <select
+            value={recordingButtonSize}
+            onChange={(e) => setRecordingButtonSize(e.target.value as RecordingButtonSize)}
+            className="w-full bg-(--m3-surface-container-highest) rounded-xl px-3 py-2.5 text-sm focus:outline-none focus:ring-1 focus:ring-(--m3-outline) appearance-none"
+          >
+            <option value="default">Default</option>
+            <option value="small">Small</option>
+            <option value="hidden">Hidden</option>
           </select>
         </div>
 
@@ -219,6 +256,15 @@ export function SettingsSheet({ open: controlledOpen, onOpenChange }: SettingsSh
               )}
             </>
           )}
+        </div>
+
+        <div className="pt-1 border-t border-(--m3-outline-variant)">
+          <button
+            onClick={() => location.reload()}
+            className="w-full mt-4 py-3 rounded-xl bg-(--m3-surface-container-highest) hover:bg-(--m3-surface-bright) text-sm font-medium transition-colors"
+          >
+            Refresh app
+          </button>
         </div>
 
         {authModalOpen && (

--- a/apps/website/src/components/messageFeedScroll.ts
+++ b/apps/website/src/components/messageFeedScroll.ts
@@ -2,6 +2,20 @@ export function getMessageFeedScrollBehavior(hasScrolledInitially: boolean): Scr
   return hasScrolledInitially ? "smooth" : "auto";
 }
 
+/** Fallback delay for pruning trimmed bubbles when `scrollend` never fires
+ *  (e.g. the feed was already at the bottom, so no scroll animation runs). */
+export const MESSAGE_FEED_PRUNE_FALLBACK_MS = 700;
+
+/**
+ * The tail of `messages` that the feed should keep mounted. `limit === null`
+ * keeps everything; otherwise the newest `limit` entries survive. Order is
+ * preserved, and the input is never mutated.
+ */
+export function selectVisibleMessages<T>(messages: readonly T[], limit: number | null): T[] {
+  if (limit === null || messages.length <= limit) return messages.slice();
+  return messages.slice(messages.length - limit);
+}
+
 export const MESSAGE_CARD_ACTION_WIDTH = 120;
 
 export const MESSAGE_CARD_SNAP_TOLERANCE = 24;

--- a/apps/website/src/store.test.ts
+++ b/apps/website/src/store.test.ts
@@ -61,6 +61,26 @@ test("stores audio processing mode in localStorage", async () => {
   expect($audioProcessingMode.get()).toBe("off");
 });
 
+test("stores transcript list mode in localStorage", async () => {
+  const { $transcriptListMode, setTranscriptListMode } = await import("./store.ts");
+
+  expect($transcriptListMode.get()).toBe("all");
+
+  setTranscriptListMode("latest");
+  expect($transcriptListMode.get()).toBe("latest");
+  expect(localStorage.getItem("vxbeamer_transcript_list_mode")).toBe("latest");
+});
+
+test("stores recording button size in localStorage", async () => {
+  const { $recordingButtonSize, setRecordingButtonSize } = await import("./store.ts");
+
+  expect($recordingButtonSize.get()).toBe("default");
+
+  setRecordingButtonSize("hidden");
+  expect($recordingButtonSize.get()).toBe("hidden");
+  expect(localStorage.getItem("vxbeamer_recording_button_size")).toBe("hidden");
+});
+
 test("backend URL defaults to blank", async () => {
   const { $backendUrl } = await import("./store.ts");
 

--- a/apps/website/src/store.ts
+++ b/apps/website/src/store.ts
@@ -25,6 +25,8 @@ const REFRESH_TOKEN_KEY = "vxbeamer_refresh_token";
 const WAKE_LOCK_KEY = "vxbeamer_wake_lock";
 const AUDIO_PROCESSING_KEY = "vxbeamer_audio_processing";
 const DESKTOP_SWIPE_BEHAVIOR_KEY = "vxbeamer_desktop_swipe_behavior";
+const TRANSCRIPT_LIST_MODE_KEY = "vxbeamer_transcript_list_mode";
+const RECORDING_BUTTON_SIZE_KEY = "vxbeamer_recording_button_size";
 const TOKEN_CHECK_INTERVAL_SECONDS = 60; // Check every minute if we need to refresh
 // Keep locally triggered swipes pending long enough for the matching SSE echo to arrive.
 const PENDING_LOCAL_SWIPE_TIMEOUT_MS = 5000;
@@ -106,6 +108,36 @@ export function setAudioProcessingMode(mode: AudioProcessingMode): void {
 export function setDesktopSwipeBehavior(mode: DesktopSwipeBehavior): void {
   $desktopSwipeBehavior.set(mode);
   localStorage.setItem(DESKTOP_SWIPE_BEHAVIOR_KEY, mode);
+}
+
+// How many transcripts the feed keeps on screen. "latest" trims to the newest
+// TRANSCRIPT_LIST_LIMIT bubbles; a purely visual, per-browser preference.
+export type TranscriptListMode = "all" | "latest";
+export const TRANSCRIPT_LIST_LIMIT = 10;
+
+function loadTranscriptListMode(): TranscriptListMode {
+  return localStorage.getItem(TRANSCRIPT_LIST_MODE_KEY) === "latest" ? "latest" : "all";
+}
+
+export const $transcriptListMode = atom<TranscriptListMode>(loadTranscriptListMode());
+
+export function setTranscriptListMode(mode: TranscriptListMode): void {
+  $transcriptListMode.set(mode);
+  localStorage.setItem(TRANSCRIPT_LIST_MODE_KEY, mode);
+}
+
+export type RecordingButtonSize = "default" | "small" | "hidden";
+
+function loadRecordingButtonSize(): RecordingButtonSize {
+  const value = localStorage.getItem(RECORDING_BUTTON_SIZE_KEY);
+  return value === "small" || value === "hidden" ? value : "default";
+}
+
+export const $recordingButtonSize = atom<RecordingButtonSize>(loadRecordingButtonSize());
+
+export function setRecordingButtonSize(size: RecordingButtonSize): void {
+  $recordingButtonSize.set(size);
+  localStorage.setItem(RECORDING_BUTTON_SIZE_KEY, size);
 }
 
 export const $backendUrl = atom<string>(localStorage.getItem(BACKEND_URL_KEY) ?? "");


### PR DESCRIPTION
Adds four new settings and makes the settings sheet scrollable. All changes are frontend-only.

## What's new

- **Transcript history** — `Show all` (default) or `Latest 10 only`. In "latest" mode the feed trims to the newest 10 bubbles. The prune is **deferred**: when a new transcript arrives, old bubbles stay mounted until the auto-scroll has come to rest (detected via `scrollend`, with a 700ms fallback for when the feed is already at the bottom), so nothing pops out of view mid-animation. Retention is applied during render (state-update-in-render pattern) so it's flicker-free.
- **Recording button** — `Default` / `Small` / `Hidden`. "Small" shrinks the button and its container; "Hidden" removes the recording bar entirely for display-only use. The header settings gear still opens settings so the button can be restored, and `RecordingBar` stays mounted so an in-progress recording and the always-on wake lock keep working.
- **Refresh app** — a button that calls `location.reload()`.
- **Scrollable settings** — the sheet now caps at `85dvh` with `overflow-y-auto` so it no longer runs off-screen as more settings are added.

Each preference persists to `localStorage` per browser, following the existing settings pattern in `store.ts`.

## Implementation notes

- New atoms/setters in `store.ts`: `$transcriptListMode` / `setTranscriptListMode` and `$recordingButtonSize` / `setRecordingButtonSize`, plus the `TRANSCRIPT_LIST_LIMIT` constant.
- New pure helper `selectVisibleMessages(messages, limit)` in `messageFeedScroll.ts` (limit `null` = keep all) — the deferred-prune orchestration lives in `MessageFeed.tsx`.
- `MessageFeed` now keeps a scroll-container ref and holds trimmed-away bubbles in a `snapshot.retainedIds` set until the scroll settles.

## Testing

- `vp check` (format + lint + types) passes.
- `vp test` — 101 tests pass, including new coverage for `selectVisibleMessages`, both new store settings, and the updated settings-sheet markup.
- Production build succeeds.
- Verified in the browser: settings sheet with the new controls + Refresh app, and all three recording-button modes (default / small / hidden).

## Note

The task called the transcript setting "transcript list size" and asked for better wording — I went with **Transcript history** (`Show all` / `Latest 10 only`). Easy to rename to something like "Visible transcripts" if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015K3XxPVEZMKpNq63fp3M5Y

---
_Generated by [Claude Code](https://claude.ai/code/session_015K3XxPVEZMKpNq63fp3M5Y)_