### PR TITLE
feat(website): tighten recording bar padding in small mode

### DIFF
--- a/.changeset/small-recording-bar-padding.md
+++ b/.changeset/small-recording-bar-padding.md
@@ -1,0 +1,5 @@
+---
+"website": patch
+---
+
+Tighten the recording bar's vertical padding when the recording button is set to small, so the bar takes less vertical space and leaves more room for the transcript feed.

--- a/apps/website/src/components/RecordingBar.tsx
+++ b/apps/website/src/components/RecordingBar.tsx
@@ -254,7 +254,9 @@ export function RecordingBar({
   const settingsIconSize = isSmall ? 28 : 40;
 
   return (
-    <div className="flex-none border-t border-(--m3-outline-variant) px-4 py-4">
+    <div
+      className={`flex-none border-t border-(--m3-outline-variant) px-4 ${isSmall ? "py-1.5" : "py-4"}`}
+    >
       {error && <p className="text-xs text-(--m3-error) mb-2 text-center">{error}</p>}
       <div className={`relative flex items-center justify-center ${isSmall ? "h-24" : "h-32"}`}>
         <canvas


### PR DESCRIPTION
Follow-up to #78. When the recording button is set to **small**, the button area's vertical padding is reduced (`py-4` → `py-1.5`), so the recording bar takes up less vertical space and leaves more room for the transcript feed. Default and hidden modes are unchanged.

## Testing

- `vp check` (format + lint + types) passes.
- Verified in the browser: the small-mode bar now sits tighter against its top border.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015K3XxPVEZMKpNq63fp3M5Y

---
_Generated by [Claude Code](https://claude.ai/code/session_015K3XxPVEZMKpNq63fp3M5Y)_