### PR TITLE
Reclaim vendor connections: kick idle sockets, tear down on error

### DIFF
--- a/.changeset/websocket-idle-cleanup.md
+++ b/.changeset/websocket-idle-cleanup.md
@@ -11,7 +11,7 @@ those open for its whole life. Two gaps let those connections leak until the cap
 was hit:
 
 - **No way to hang up an abandoned session.** `ASRSession` only exposed
-  `sendAudio()` and `finish()`, and `finish()` is *graceful* — it waits for the
+  `sendAudio()` and `finish()`, and `finish()` is _graceful_ — it waits for the
   vendor's terminal event, which never comes for a socket that has simply gone
   silent. `ASRSession.close()` is new: an immediate, idempotent teardown that
   `terminate()`s the vendor socket and emits no further callbacks, so a session
@@ -27,6 +27,6 @@ was hit:
 Idle-kicking is now enforced at the socket layer: a watchdog, armed when the
 vendor session opens and deferred on every audio frame, closes the client and
 aborts the vendor session after `WS_IDLE_TIMEOUT_MS` of silence (default 60s; a
-non-positive value disables it). It watches *audio*, not liveness, so a client
+non-positive value disables it). It watches _audio_, not liveness, so a client
 that keeps the socket open but stops speaking is still reclaimed. The watchdog is
 disarmed on `stop`, since finalisation is the vendor's clock, not the client's.

--- a/.changeset/websocket-idle-cleanup.md
+++ b/.changeset/websocket-idle-cleanup.md
@@ -1,0 +1,32 @@
+---
+"vxasr": patch
+"backend": patch
+---
+
+Reclaim upstream vendor connections: kick idle sockets and always tear down on error
+
+The realtime vendors cap concurrent connections per account ("connections too
+much max_connections 100"), and each `/ws` (and `/asr/eval`) socket holds one of
+those open for its whole life. Two gaps let those connections leak until the cap
+was hit:
+
+- **No way to hang up an abandoned session.** `ASRSession` only exposed
+  `sendAudio()` and `finish()`, and `finish()` is *graceful* — it waits for the
+  vendor's terminal event, which never comes for a socket that has simply gone
+  silent. `ASRSession.close()` is new: an immediate, idempotent teardown that
+  `terminate()`s the vendor socket and emits no further callbacks, so a session
+  that can no longer produce a transcript releases its slot rather than holding
+  it until the vendor reaps it.
+
+- **Error paths left the socket open.** Every provider's `ws.on("error")` now
+  closes the socket, and Qwen now hangs up on a vendor `error` frame the way
+  BytePlus and Qwen-Omni already did — previously it did not, so a
+  "max_connections" error frame itself leaked another connection, compounding the
+  very condition it reported.
+
+Idle-kicking is now enforced at the socket layer: a watchdog, armed when the
+vendor session opens and deferred on every audio frame, closes the client and
+aborts the vendor session after `WS_IDLE_TIMEOUT_MS` of silence (default 60s; a
+non-positive value disables it). It watches *audio*, not liveness, so a client
+that keeps the socket open but stops speaking is still reclaimed. The watchdog is
+disarmed on `stop`, since finalisation is the vendor's clock, not the client's.

--- a/apps/backend/src/evalSocket.test.ts
+++ b/apps/backend/src/evalSocket.test.ts
@@ -1,4 +1,4 @@
-import { expect, test, vi } from "vite-plus/test";
+import { afterEach, expect, test, vi } from "vite-plus/test";
 import type { WSContext, WSMessageReceive } from "hono/ws";
 import type { ASRProvider, ASRSessionCallbacks } from "vxasr";
 import type { EvalServerEvent, EvalSocketOptions } from "./evalSocket.ts";
@@ -22,12 +22,14 @@ function createControllableProvider() {
   const audio: Buffer[] = [];
   let callbacks: ASRSessionCallbacks | undefined;
   let finishes = 0;
+  let closes = 0;
   const provider: ASRProvider = {
     createSession(cb) {
       callbacks = cb;
       return {
         sendAudio: (chunk) => void audio.push(chunk),
         finish: () => void finishes++,
+        close: () => void closes++,
       };
     },
   };
@@ -36,6 +38,9 @@ function createControllableProvider() {
     audio,
     get finishes() {
       return finishes;
+    },
+    get closes() {
+      return closes;
     },
     emit: () => callbacks!,
   };
@@ -47,6 +52,9 @@ function createOptions(
   const provider = overrides.provider ?? createControllableProvider().provider;
   return {
     configuration: CONFIGURATION_ID,
+    // Off by default so behavioural tests do not leave a real timer armed; the
+    // idle tests below opt in with an explicit value under fake timers.
+    idleTimeoutMs: 0,
     selector: {
       select: () => ({ ok: true, selection: { provider, configurationId: CONFIGURATION_ID } }),
     },
@@ -254,4 +262,96 @@ test("the configuration named by the client is the one selected", () => {
     type: "ready",
     configurationId: "qwen/qwen3-asr-flash-realtime+groq",
   });
+});
+
+// --- Kicking an idle session ---
+//
+// Each open session holds one vendor connection, and the vendors cap those per
+// account ("connections too much max_connections 100"). A client that opens a
+// socket and then falls silent — never sending `stop`, never hanging up — would
+// otherwise pin its connection until the vendor reaps it, so the watchdog
+// reclaims it. The eval fan-out makes this sharper: it opens one socket per
+// configuration, so a single stalled run can hold several slots at once.
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+test("kicks a session that goes silent, aborting the vendor connection", () => {
+  vi.useFakeTimers();
+  const controllable = createControllableProvider();
+  const handler = createEvalSocketHandler(
+    createOptions({ provider: controllable.provider, idleTimeoutMs: 60_000 }),
+  );
+  const { ws, sent, closes } = createFakeWs();
+
+  handler.onOpen(new Event("open"), ws);
+  vi.advanceTimersByTime(60_000);
+
+  // `close()`, not `finish()`: an abandoned session must be aborted, since the
+  // graceful finish waits for a terminal event silence will never produce.
+  expect(controllable.closes).toBe(1);
+  expect(controllable.finishes).toBe(0);
+  expect(sent.at(-1)).toEqual({
+    type: "error",
+    message: "Idle timeout: no audio received for 60s",
+  });
+  expect(closes).toEqual([{ code: 1008, reason: "idle timeout" }]);
+});
+
+test("audio frames defer the idle deadline", () => {
+  vi.useFakeTimers();
+  const controllable = createControllableProvider();
+  const handler = createEvalSocketHandler(
+    createOptions({ provider: controllable.provider, idleTimeoutMs: 60_000 }),
+  );
+  const { ws, closes } = createFakeWs();
+
+  handler.onOpen(new Event("open"), ws);
+  // Audio just under the deadline, repeatedly: the session must survive as long
+  // as it keeps sending.
+  for (let i = 0; i < 5; i++) {
+    vi.advanceTimersByTime(59_000);
+    handler.onMessage(binaryFrame(new Uint8Array([1]).buffer), ws);
+  }
+  expect(closes).toEqual([]);
+  expect(controllable.closes).toBe(0);
+
+  // Then let it fall silent past the deadline.
+  vi.advanceTimersByTime(60_000);
+  expect(closes).toEqual([{ code: 1008, reason: "idle timeout" }]);
+});
+
+test("a session that has stopped is not later kicked as idle", () => {
+  vi.useFakeTimers();
+  const controllable = createControllableProvider();
+  const handler = createEvalSocketHandler(
+    createOptions({ provider: controllable.provider, idleTimeoutMs: 60_000 }),
+  );
+  const { ws, closes } = createFakeWs();
+
+  handler.onOpen(new Event("open"), ws);
+  handler.onMessage(textFrame({ type: "stop" }), ws);
+  // The vendor may take longer than the idle window to finalise; that wait is
+  // the vendor's, not the client's, so the watchdog is disarmed on `stop`.
+  vi.advanceTimersByTime(600_000);
+
+  expect(controllable.finishes).toBe(1);
+  expect(controllable.closes).toBe(0);
+  expect(closes).toEqual([]);
+});
+
+test("idle-kicking is disabled by a non-positive timeout", () => {
+  vi.useFakeTimers();
+  const controllable = createControllableProvider();
+  const handler = createEvalSocketHandler(
+    createOptions({ provider: controllable.provider, idleTimeoutMs: 0 }),
+  );
+  const { ws, closes } = createFakeWs();
+
+  handler.onOpen(new Event("open"), ws);
+  vi.advanceTimersByTime(600_000);
+
+  expect(closes).toEqual([]);
+  expect(controllable.closes).toBe(0);
 });

--- a/apps/backend/src/evalSocket.ts
+++ b/apps/backend/src/evalSocket.ts
@@ -1,6 +1,7 @@
 import type { WSContext, WSMessageReceive } from "hono/ws";
 import type { ASRSession, UsageRecord } from "vxasr";
 import type { ConfigurationSelector } from "./asr.ts";
+import { createIdleWatchdog, type IdleWatchdog } from "./idleWatchdog.ts";
 import { normalizeTranscriptText } from "./transcript.ts";
 
 /**
@@ -41,7 +42,16 @@ export interface EvalSocketOptions {
   selector: Pick<ConfigurationSelector, "select">;
   /** The `?configuration=` query param, if the client sent a non-empty one. */
   configuration: string | undefined;
+  /**
+   * Kick the session if it goes this long without audio, reclaiming its vendor
+   * connection — the same cap the recording socket guards against. An eval
+   * fans one of these out per configuration, so a stalled fan-out can hold
+   * several vendor slots at once. Non-positive disables it; defaults to 60s.
+   */
+  idleTimeoutMs?: number;
 }
+
+const DEFAULT_IDLE_TIMEOUT_MS = 60_000;
 
 /**
  * A `hono/ws` handler set. Structurally typed rather than imported as `WSEvents`
@@ -54,9 +64,11 @@ export interface EvalSocketHandler {
 }
 
 export function createEvalSocketHandler(options: EvalSocketOptions): EvalSocketHandler {
+  const idleTimeoutMs = options.idleTimeoutMs ?? DEFAULT_IDLE_TIMEOUT_MS;
   let session: ASRSession | null = null;
   let finished = false;
   let closed = false;
+  let idle: IdleWatchdog | null = null;
 
   const send = (ws: WSContext, event: EvalServerEvent): void => {
     if (closed) return;
@@ -66,6 +78,7 @@ export function createEvalSocketHandler(options: EvalSocketOptions): EvalSocketH
   const close = (ws: WSContext, code: number, reason: string): void => {
     if (closed) return;
     closed = true;
+    idle?.stop();
     ws.close(code, reason);
   };
 
@@ -104,6 +117,22 @@ export function createEvalSocketHandler(options: EvalSocketOptions): EvalSocketH
         },
       });
 
+      // A vendor connection is now open. Kick the session if it falls silent so
+      // an abandoned eval replay releases that connection — an eval fans one of
+      // these out per configuration, so a stalled fan-out can otherwise pin
+      // several of the vendor's capped slots at once. `close()` aborts the
+      // vendor socket; the graceful `finish()` waits for an end silence will
+      // never produce.
+      idle = createIdleWatchdog(idleTimeoutMs, () => {
+        if (closed) return;
+        session?.close();
+        send(ws, {
+          type: "error",
+          message: `Idle timeout: no audio received for ${Math.round(idleTimeoutMs / 1000)}s`,
+        });
+        close(ws, 1008, "idle timeout");
+      });
+
       // Announced only once the vendor session exists, so a client that waits
       // for it is not pacing 100 ms frames into a socket about to close.
       send(ws, { type: "ready", configurationId });
@@ -112,8 +141,10 @@ export function createEvalSocketHandler(options: EvalSocketOptions): EvalSocketH
     onMessage(evt: MessageEvent<WSMessageReceive>) {
       const { data } = evt;
       if (data instanceof ArrayBuffer) {
+        idle?.poke();
         session?.sendAudio(Buffer.from(data));
       } else if (ArrayBuffer.isView(data)) {
+        idle?.poke();
         session?.sendAudio(
           Buffer.from(data.buffer as ArrayBuffer, data.byteOffset, data.byteLength),
         );
@@ -122,6 +153,9 @@ export function createEvalSocketHandler(options: EvalSocketOptions): EvalSocketH
           const message = JSON.parse(data) as { type?: string };
           if (message.type === "stop" && !finished) {
             finished = true;
+            // The client is done sending; the vendor now owns the clock while it
+            // finalises, so stop watching for client silence.
+            idle?.stop();
             session?.finish();
           }
         } catch {
@@ -132,6 +166,7 @@ export function createEvalSocketHandler(options: EvalSocketOptions): EvalSocketH
 
     onClose() {
       closed = true;
+      idle?.stop();
       if (!finished) {
         finished = true;
         session?.finish();

--- a/apps/backend/src/idleWatchdog.test.ts
+++ b/apps/backend/src/idleWatchdog.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, expect, test, vi } from "vite-plus/test";
+import { createIdleWatchdog } from "./idleWatchdog.ts";
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+test("fires once the timeout elapses with no poke", () => {
+  vi.useFakeTimers();
+  let fired = 0;
+  createIdleWatchdog(1000, () => void fired++);
+
+  vi.advanceTimersByTime(999);
+  expect(fired).toBe(0);
+  vi.advanceTimersByTime(1);
+  expect(fired).toBe(1);
+});
+
+test("each poke defers the deadline by a full timeout", () => {
+  vi.useFakeTimers();
+  let fired = 0;
+  const watchdog = createIdleWatchdog(1000, () => void fired++);
+
+  for (let i = 0; i < 10; i++) {
+    vi.advanceTimersByTime(900);
+    watchdog.poke();
+  }
+  expect(fired).toBe(0);
+
+  vi.advanceTimersByTime(1000);
+  expect(fired).toBe(1);
+});
+
+test("stop cancels a pending deadline", () => {
+  vi.useFakeTimers();
+  let fired = 0;
+  const watchdog = createIdleWatchdog(1000, () => void fired++);
+
+  watchdog.stop();
+  vi.advanceTimersByTime(10_000);
+  expect(fired).toBe(0);
+});
+
+test("fires at most once, and a later poke does not re-arm it", () => {
+  vi.useFakeTimers();
+  let fired = 0;
+  const watchdog = createIdleWatchdog(1000, () => void fired++);
+
+  vi.advanceTimersByTime(1000);
+  expect(fired).toBe(1);
+
+  // A frame racing the teardown must not resurrect a spent watchdog.
+  watchdog.poke();
+  vi.advanceTimersByTime(10_000);
+  expect(fired).toBe(1);
+});
+
+test("a non-positive timeout is inert", () => {
+  vi.useFakeTimers();
+  let fired = 0;
+  const zero = createIdleWatchdog(0, () => void fired++);
+  const negative = createIdleWatchdog(-1000, () => void fired++);
+
+  zero.poke();
+  negative.poke();
+  vi.advanceTimersByTime(10_000);
+  expect(fired).toBe(0);
+});

--- a/apps/backend/src/idleWatchdog.ts
+++ b/apps/backend/src/idleWatchdog.ts
@@ -1,0 +1,67 @@
+/**
+ * A resettable deadline that fires when a socket has gone quiet for too long.
+ *
+ * Every `/ws` (and `/asr/eval`) connection holds one upstream vendor socket
+ * open, and those are metered and capped — the vendors reject new connections
+ * past a per-account limit ("connections too much max_connections 100"). A
+ * client that opens a socket and then stops sending audio without ever sending
+ * `stop` — a backgrounded app, a dropped network, a leaked tab — pins its vendor
+ * connection open indefinitely, because the graceful `finish()` path waits for a
+ * terminal event the vendor will never send for silence. Enough of those and the
+ * pool is exhausted for everyone.
+ *
+ * This is the reclaim: arm a deadline when the session opens, {@link poke} it
+ * forward on every audio frame, and when it elapses the caller tears the session
+ * down. It watches *audio*, not liveness — a client can hold the socket open and
+ * still be kicked, which is exactly the case a WebSocket ping/pong would miss.
+ */
+export interface IdleWatchdog {
+  /** Defer the deadline by one full timeout. Call on each audio frame. */
+  poke(): void;
+  /** Cancel the deadline. Idempotent; call whenever the socket settles. */
+  stop(): void;
+}
+
+/**
+ * Creates a watchdog that calls {@link onIdle} once, `timeoutMs` after the most
+ * recent {@link IdleWatchdog.poke} (or after creation, since a client that
+ * connects and sends nothing at all is the worst offender to reclaim).
+ *
+ * A non-positive `timeoutMs` disables the watchdog entirely — the returned
+ * handle is inert — so an operator can turn idle-kicking off with
+ * `WS_IDLE_TIMEOUT_MS=0` without the call sites growing a branch.
+ *
+ * `onIdle` fires at most once: after it fires the watchdog is spent, and a
+ * `poke` arriving later (a frame racing the teardown) does not re-arm it.
+ */
+export function createIdleWatchdog(timeoutMs: number, onIdle: () => void): IdleWatchdog {
+  if (!(timeoutMs > 0)) {
+    return { poke() {}, stop() {} };
+  }
+
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  let done = false;
+
+  const arm = () => {
+    if (done) return;
+    if (timer) clearTimeout(timer);
+    timer = setTimeout(() => {
+      timer = null;
+      done = true;
+      onIdle();
+    }, timeoutMs);
+  };
+
+  arm();
+
+  return {
+    poke: arm,
+    stop() {
+      done = true;
+      if (timer) {
+        clearTimeout(timer);
+        timer = null;
+      }
+    },
+  };
+}

--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -7,6 +7,7 @@ import { createNodeWebSocket } from "@hono/node-ws";
 import type { WSContext, WSMessageReceive } from "hono/ws";
 import type { ASRSession } from "vxasr";
 import { createConfigurationSelector } from "./asr.ts";
+import { createIdleWatchdog, type IdleWatchdog } from "./idleWatchdog.ts";
 import {
   type AccessTokenPayload,
   createAccessToken,
@@ -41,6 +42,11 @@ const apiKeys = new Map(
     }),
 );
 const webhookUrl = process.env.WEBHOOK_URL ?? "";
+// How long a recording socket may go without audio before it is kicked and its
+// upstream vendor connection reclaimed. Vendor connections are capped per
+// account, so an abandoned session that never sends `stop` must not pin one
+// open forever. `0` (or any non-positive value) disables idle-kicking.
+const wsIdleTimeoutMs = Number(process.env.WS_IDLE_TIMEOUT_MS ?? "60000");
 // Throws on an unknown ASR_CONFIGURATION/ASR_PROVIDER/ASR_CONFIGURATIONS, so a
 // typo fails the boot rather than silently transcribing with the wrong model.
 const configurationSelector = createConfigurationSelector(process.env);
@@ -401,6 +407,10 @@ app.get(
     let asrSession: ASRSession | null = null;
     let message: Message | null = null;
     let finished = false;
+    // Guards the message's terminal transition so the socket settles once,
+    // whichever of end / error / idle-timeout gets there first.
+    let settled = false;
+    let idle: IdleWatchdog | null = null;
     const referenceId = c.req.query("reference_id");
     const configurationParam = nonEmptyQuery(c.req.query("configuration"));
 
@@ -445,7 +455,9 @@ app.get(
             store.broadcast(subject, { type: "updated", message });
           },
           onEnd() {
-            if (!message) return;
+            if (!message || settled) return;
+            settled = true;
+            idle?.stop();
             message.status = "done";
             message.updatedAt = Date.now();
             store.broadcast(subject, { type: "updated", message });
@@ -453,7 +465,9 @@ app.get(
             ws.close(1000, "done");
           },
           onError(err) {
-            if (!message) return;
+            if (!message || settled) return;
+            settled = true;
+            idle?.stop();
             message.status = "error";
             message.error = err instanceof Error ? err.message : String(err);
             message.updatedAt = Date.now();
@@ -462,13 +476,37 @@ app.get(
             ws.close(1011, "ASR error");
           },
         });
+
+        // From here a vendor connection is open. Kick the session if it falls
+        // silent, so an abandoned recording releases that connection rather than
+        // holding one of the vendor's capped slots until it reaps the session
+        // itself. `close()` aborts the vendor socket outright — the graceful
+        // `finish()` waits for a terminal event silence will never produce.
+        idle = createIdleWatchdog(wsIdleTimeoutMs, () => {
+          if (settled) return;
+          settled = true;
+          finished = true;
+          asrSession?.close();
+          if (message) {
+            message.status = "error";
+            message.error = `Idle timeout: no audio received for ${Math.round(
+              wsIdleTimeoutMs / 1000,
+            )}s`;
+            message.updatedAt = Date.now();
+            store.broadcast(subject, { type: "updated", message });
+            void sendWebhook(message);
+          }
+          ws.close(1008, "idle timeout");
+        });
       },
 
       onMessage(evt: MessageEvent<WSMessageReceive>) {
         const { data } = evt;
         if (data instanceof ArrayBuffer) {
+          idle?.poke();
           asrSession?.sendAudio(Buffer.from(data));
         } else if (ArrayBuffer.isView(data)) {
+          idle?.poke();
           asrSession?.sendAudio(
             Buffer.from(data.buffer as ArrayBuffer, data.byteOffset, data.byteLength),
           );
@@ -477,6 +515,9 @@ app.get(
             const msg = JSON.parse(data) as { type?: string };
             if (msg.type === "stop" && !finished) {
               finished = true;
+              // The client is done sending; the vendor now owns the clock while
+              // it finalises, so stop watching for client silence.
+              idle?.stop();
               asrSession?.finish();
             }
           } catch {
@@ -486,6 +527,7 @@ app.get(
       },
 
       onClose() {
+        idle?.stop();
         if (!finished) {
           finished = true;
           asrSession?.finish();
@@ -510,6 +552,7 @@ app.get(
     createEvalSocketHandler({
       selector: configurationSelector,
       configuration: nonEmptyQuery(c.req.query("configuration")),
+      idleTimeoutMs: wsIdleTimeoutMs,
     }),
   ),
 );

--- a/packages/vxasr/src/asr.ts
+++ b/packages/vxasr/src/asr.ts
@@ -24,6 +24,19 @@ export interface ASRSession {
    */
   sendAudio(chunk: Buffer): void;
   finish(): void;
+  /**
+   * Hang up the vendor connection immediately, without waiting for a final
+   * transcript. Idempotent, and safe to call in any state.
+   *
+   * Unlike {@link finish}, this makes no attempt to end the turn gracefully: it
+   * exists so an abandoned or idle session can be reclaimed even when the vendor
+   * would never send its terminal event. These are metered, capped connections
+   * (the vendors reject new sockets past a per-account limit), so a session that
+   * can no longer produce a transcript must release its socket rather than hold
+   * it until the vendor's own session cap reaps it. After `close()`, the session
+   * emits no further callbacks — the caller asked for the teardown and owns it.
+   */
+  close(): void;
 }
 
 export interface ASRProvider {

--- a/packages/vxasr/src/providers/byteplus.ts
+++ b/packages/vxasr/src/providers/byteplus.ts
@@ -136,6 +136,7 @@ export function createBytePlusProvider(config: BytePlusProviderConfig): ASRProvi
       let buffer = Buffer.alloc(0);
       let ready = false;
       let finishing = false;
+      let closed = false;
       let totalBytesSent = 0;
 
       function flushBuffer() {
@@ -184,6 +185,7 @@ export function createBytePlusProvider(config: BytePlusProviderConfig): ASRProvi
       });
 
       ws.on("message", (raw: Buffer) => {
+        if (closed) return;
         const { isLast, text, error } = parseServerMessage(raw as Buffer);
 
         if (error) {
@@ -209,7 +211,13 @@ export function createBytePlusProvider(config: BytePlusProviderConfig): ASRProvi
         }
       });
 
-      ws.on("error", (err: Error) => callbacks.onError?.(err));
+      ws.on("error", (err: Error) => {
+        if (closed) return;
+        callbacks.onError?.(err);
+        // A transport error leaves the socket half-open; close it so its slot in
+        // the vendor's connection pool is released rather than lingering.
+        ws.close();
+      });
 
       return {
         sendAudio(chunk: Buffer) {
@@ -225,6 +233,16 @@ export function createBytePlusProvider(config: BytePlusProviderConfig): ASRProvi
           // the handshake it must follow has gone out.
           if (!ready || ws.readyState !== WebSocket.OPEN) return;
           sendLastPacket();
+        },
+
+        close() {
+          if (closed) return;
+          closed = true;
+          // Stop feeding and finishing; from here the socket is being torn down,
+          // not wound down. `terminate` releases the connection immediately in
+          // any state (CONNECTING included), which `close()` cannot promise.
+          finishing = true;
+          ws.terminate();
         },
       };
     },

--- a/packages/vxasr/src/providers/mock.ts
+++ b/packages/vxasr/src/providers/mock.ts
@@ -26,6 +26,9 @@ export function createMockProvider(): ASRProvider {
           callbacks.onFinal?.(MOCK_TRANSCRIPT);
           callbacks.onEnd?.();
         },
+        close(): void {
+          // No vendor socket behind the mock, so nothing to reclaim.
+        },
       };
     },
   };

--- a/packages/vxasr/src/providers/qwen-omni.ts
+++ b/packages/vxasr/src/providers/qwen-omni.ts
@@ -174,6 +174,7 @@ export function createQwenOmniProvider(config: QwenOmniProviderConfig): ASRProvi
       let buffer = Buffer.alloc(0);
       let ready = false;
       let finishing = false;
+      let closed = false;
       let transcript = "";
 
       function flushBuffer() {
@@ -243,6 +244,7 @@ export function createQwenOmniProvider(config: QwenOmniProviderConfig): ASRProvi
       });
 
       ws.on("message", (raw: Buffer) => {
+        if (closed) return;
         const data = JSON.parse(raw.toString());
 
         if (data.type === "response.text.delta") {
@@ -267,7 +269,13 @@ export function createQwenOmniProvider(config: QwenOmniProviderConfig): ASRProvi
         }
       });
 
-      ws.on("error", (err: Error) => callbacks.onError?.(err));
+      ws.on("error", (err: Error) => {
+        if (closed) return;
+        callbacks.onError?.(err);
+        // A transport error leaves the socket half-open; close it so its slot in
+        // the vendor's connection pool is released rather than lingering.
+        ws.close();
+      });
 
       return {
         sendAudio(chunk: Buffer) {
@@ -281,6 +289,16 @@ export function createQwenOmniProvider(config: QwenOmniProviderConfig): ASRProvi
           finishing = true;
           if (ready) doFinish();
           // else: the `open` handler calls doFinish() once the session is set up.
+        },
+
+        close() {
+          if (closed) return;
+          closed = true;
+          // Stop feeding and finishing; from here the socket is being torn down,
+          // not wound down. `terminate` releases the connection immediately in
+          // any state (CONNECTING included), which `close()` cannot promise.
+          finishing = true;
+          ws.terminate();
         },
       };
     },

--- a/packages/vxasr/src/providers/qwen.ts
+++ b/packages/vxasr/src/providers/qwen.ts
@@ -26,6 +26,7 @@ export function createQwenProvider(config: QwenProviderConfig): ASRProvider {
       let buffer = Buffer.alloc(0);
       let ready = false;
       let finishing = false;
+      let closed = false;
       let totalBytesSent = 0;
 
       function flushBuffer() {
@@ -79,6 +80,7 @@ export function createQwenProvider(config: QwenProviderConfig): ASRProvider {
       });
 
       ws.on("message", (raw: Buffer) => {
+        if (closed) return;
         const data = JSON.parse(raw.toString());
 
         if (data.type === "conversation.item.input_audio_transcription.text") {
@@ -98,10 +100,22 @@ export function createQwenProvider(config: QwenProviderConfig): ASRProvider {
           ws.close(1000, "done");
         } else if (data.type === "error") {
           callbacks.onError?.(new Error(JSON.stringify(data)));
+          // The turn is over and will produce nothing, so hang up rather than
+          // hold the socket open. An errored session still counts against the
+          // vendor's connection cap until it closes — and "connections too much"
+          // is itself one of these error frames, so leaking here compounds the
+          // very condition it reports.
+          ws.close();
         }
       });
 
-      ws.on("error", (err: Error) => callbacks.onError?.(err));
+      ws.on("error", (err: Error) => {
+        if (closed) return;
+        callbacks.onError?.(err);
+        // A transport error leaves the socket half-open; close it so its slot in
+        // the vendor's connection pool is released rather than lingering.
+        ws.close();
+      });
 
       return {
         sendAudio(chunk: Buffer) {
@@ -115,6 +129,16 @@ export function createQwenProvider(config: QwenProviderConfig): ASRProvider {
           finishing = true;
           if (ready) doFinish();
           // else: doFinish() will be called from the 'open' handler
+        },
+
+        close() {
+          if (closed) return;
+          closed = true;
+          // Stop feeding and finishing; from here the socket is being torn down,
+          // not wound down. `terminate` releases the connection immediately in
+          // any state (CONNECTING included), which `close()` cannot promise.
+          finishing = true;
+          ws.terminate();
         },
       };
     },

--- a/packages/vxasr/tests/registry.test.ts
+++ b/packages/vxasr/tests/registry.test.ts
@@ -6,7 +6,9 @@ import {
   type ASRProvider,
 } from "../src/index.ts";
 
-const fakeProvider: ASRProvider = { createSession: () => ({ sendAudio() {}, finish() {} }) };
+const fakeProvider: ASRProvider = {
+  createSession: () => ({ sendAudio() {}, finish() {}, close() {} }),
+};
 
 /** A provider whose config is deliberately not `{ apiKey }`. */
 function defineRegionProvider(seen: { config?: unknown; model?: string }) {


### PR DESCRIPTION
## Why

The realtime ASR vendors cap concurrent connections per account — the errors in the report are the vendor's: `{"code":"COMMON_ERROR","message":"connections too much max_connections 100"}`. Every `/ws` and `/asr/eval` socket holds **one** vendor WebSocket open for its whole life, and we were leaking them until the cap was hit.

## What was leaking

1. **No way to hang up an abandoned session.** `ASRSession` exposed only `sendAudio()` and `finish()`, and `finish()` is *graceful* — it waits for the vendor's terminal event, which never arrives for a socket that has simply gone silent. Nothing could force a teardown.
2. **Error paths left the socket open.** Every provider's `ws.on("error")` handler called `onError` but never closed the socket. And Qwen ignored vendor `error` frames entirely (BytePlus and Qwen-Omni already `ws.close()` on them) — so a `max_connections` frame *itself leaked another connection*, compounding the very condition it reports.
3. **No idle timeout anywhere.** A client could open `/ws`, spin up a vendor socket, then go silent forever. The only timer in the backend was the SSE keepalive.

## What this changes

- **`ASRSession.close()`** — a new immediate, idempotent teardown that `terminate()`s the vendor socket and suppresses any further callbacks, so a session that can no longer produce a transcript releases its slot instead of holding it until the vendor reaps it. Implemented in `qwen`, `qwen-omni`, `byteplus`, and `mock`; the Groq decorator forwards it (it returns the inner session unchanged).
- **Closed the error-path leaks** — every provider's `ws.on("error")` now closes the socket, and Qwen now hangs up on a vendor `error` frame the way the other two already did.
- **Idle watchdog** (`apps/backend/src/idleWatchdog.ts`) wired into both `/ws` and `/asr/eval`: armed when the vendor session opens, deferred on every audio frame, and disarmed on `stop` (finalisation is the vendor's clock, not the client's). After `WS_IDLE_TIMEOUT_MS` of silence (default **60s**; a non-positive value disables it) it aborts the vendor session via `close()` and closes the client (`1008`). It watches *audio*, not liveness, so a client that keeps the socket open but stops speaking is still reclaimed — a case a WebSocket ping/pong would miss.
- A `settled` guard on the `/ws` terminal transitions (end / error / idle) so the message settles exactly once, whichever gets there first.

## Behaviour notes

- An idle-killed recording is marked `error` with `Idle timeout: no audio received for Ns` and broadcast/webhooked like any other terminal transition — an honest, visible state rather than a silent hang.
- The eval fan-out opens one socket per configuration, so a stalled run could pin several vendor slots at once; the same watchdog covers it.

## Tests

- `idleWatchdog.test.ts` — deadline fires once, each poke defers a full timeout, `stop` cancels, a spent watchdog does not re-arm, non-positive is inert.
- `evalSocket.test.ts` — a silent session is kicked and the vendor session aborted (`close()`, not `finish()`); audio frames defer the deadline; a stopped session is not later kicked; a non-positive timeout disables kicking.

## Caveat

The sandbox denied `vp install`, so `vp check` / `vp test` could **not** be run here — changes were verified by manual review (including fixing a typed test fake in `registry.test.ts` that the new required `close()` would otherwise break). Please run `vp install && vp check && vp test` before merge; CI covers the same.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TiGhRR7pPJgqZLeDSfXYNs

---
_Generated by [Claude Code](https://claude.ai/code/session_01TiGhRR7pPJgqZLeDSfXYNs)_