### PR TITLE
Extract shared streaming-WebSocket session plumbing

### DIFF
--- a/.changeset/buffered-socket-session.md
+++ b/.changeset/buffered-socket-session.md
@@ -1,0 +1,33 @@
+---
+"vxasr": patch
+"backend": patch
+"website": patch
+---
+
+Extract the shared streaming-WebSocket plumbing from the three providers
+
+Qwen, Qwen-Omni and BytePlus each carried ~35 lines of identical session
+plumbing — buffer/ready/finishing state, the chunk-flush loop, the
+pre-open-finish race, the error handler, and (since the connection-cleanup
+work) `close()` — and the three copies had already drifted (dtinth/vxbeamer#72).
+That plumbing now lives once in `createBufferedSocketSession`; each provider
+supplies only what is genuinely per-vendor: the handshake, frame encoding,
+turn-end, and message parsing. Byte accounting stays with the provider, so a
+token-billed vendor (Qwen-Omni) is never forced into the per-audio-second
+assumption the other two make.
+
+This also settles the `finish()` drift the duplication had produced: BytePlus
+guarded the turn-end with a socket-open check that Qwen and Qwen-Omni lacked, so
+finishing those two after a post-open socket error fired a spurious `onError`.
+The guard now lives in the shared helper and applies to all three.
+
+Alongside, three smaller copies collapse (no behaviour change):
+
+- `readAudioFrame` / `isStopMessage` — the binary-frame decode (including the
+  `byteOffset`/`byteLength` care) and the `stop`-message parse shared by the
+  recording and eval sockets. The decoder reaches nothing in the message log, so
+  the eval socket's isolation from the store is preserved.
+- `buildBackendSocketUrl` — the `http(s)`→`ws(s)` URL build shared by the
+  recording bar and the eval fan-out.
+- `concatChunks` — the retained-chunk flatten shared by the WAV writer and the
+  eval frame re-cutter.

--- a/apps/backend/src/evalSocket.ts
+++ b/apps/backend/src/evalSocket.ts
@@ -3,6 +3,7 @@ import type { ASRSession, UsageRecord } from "vxasr";
 import type { ConfigurationSelector } from "./asr.ts";
 import { createIdleWatchdog, type IdleWatchdog } from "./idleWatchdog.ts";
 import { normalizeTranscriptText } from "./transcript.ts";
+import { isStopMessage, readAudioFrame } from "./wsFrame.ts";
 
 /**
  * The eval replay socket: transcription with no message log behind it.
@@ -139,28 +140,16 @@ export function createEvalSocketHandler(options: EvalSocketOptions): EvalSocketH
     },
 
     onMessage(evt: MessageEvent<WSMessageReceive>) {
-      const { data } = evt;
-      if (data instanceof ArrayBuffer) {
+      const audio = readAudioFrame(evt.data);
+      if (audio !== null) {
         idle?.poke();
-        session?.sendAudio(Buffer.from(data));
-      } else if (ArrayBuffer.isView(data)) {
-        idle?.poke();
-        session?.sendAudio(
-          Buffer.from(data.buffer as ArrayBuffer, data.byteOffset, data.byteLength),
-        );
-      } else if (typeof data === "string") {
-        try {
-          const message = JSON.parse(data) as { type?: string };
-          if (message.type === "stop" && !finished) {
-            finished = true;
-            // The client is done sending; the vendor now owns the clock while it
-            // finalises, so stop watching for client silence.
-            idle?.stop();
-            session?.finish();
-          }
-        } catch {
-          // ignore invalid messages
-        }
+        session?.sendAudio(audio);
+      } else if (isStopMessage(evt.data) && !finished) {
+        finished = true;
+        // The client is done sending; the vendor now owns the clock while it
+        // finalises, so stop watching for client silence.
+        idle?.stop();
+        session?.finish();
       }
     },
 

--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -8,6 +8,7 @@ import type { WSContext, WSMessageReceive } from "hono/ws";
 import type { ASRSession } from "vxasr";
 import { createConfigurationSelector } from "./asr.ts";
 import { createIdleWatchdog, type IdleWatchdog } from "./idleWatchdog.ts";
+import { isStopMessage, readAudioFrame } from "./wsFrame.ts";
 import {
   type AccessTokenPayload,
   createAccessToken,
@@ -501,28 +502,16 @@ app.get(
       },
 
       onMessage(evt: MessageEvent<WSMessageReceive>) {
-        const { data } = evt;
-        if (data instanceof ArrayBuffer) {
+        const audio = readAudioFrame(evt.data);
+        if (audio !== null) {
           idle?.poke();
-          asrSession?.sendAudio(Buffer.from(data));
-        } else if (ArrayBuffer.isView(data)) {
-          idle?.poke();
-          asrSession?.sendAudio(
-            Buffer.from(data.buffer as ArrayBuffer, data.byteOffset, data.byteLength),
-          );
-        } else if (typeof data === "string") {
-          try {
-            const msg = JSON.parse(data) as { type?: string };
-            if (msg.type === "stop" && !finished) {
-              finished = true;
-              // The client is done sending; the vendor now owns the clock while
-              // it finalises, so stop watching for client silence.
-              idle?.stop();
-              asrSession?.finish();
-            }
-          } catch {
-            // ignore invalid messages
-          }
+          asrSession?.sendAudio(audio);
+        } else if (isStopMessage(evt.data) && !finished) {
+          finished = true;
+          // The client is done sending; the vendor now owns the clock while it
+          // finalises, so stop watching for client silence.
+          idle?.stop();
+          asrSession?.finish();
         }
       },
 

--- a/apps/backend/src/wsFrame.test.ts
+++ b/apps/backend/src/wsFrame.test.ts
@@ -1,0 +1,48 @@
+import { expect, test } from "vite-plus/test";
+import type { WSMessageReceive } from "hono/ws";
+import { isStopMessage, readAudioFrame } from "./wsFrame.ts";
+
+const frame = (data: unknown) => data as WSMessageReceive;
+
+test("reads an ArrayBuffer as its bytes", () => {
+  const audio = readAudioFrame(frame(new Uint8Array([1, 2, 3, 4]).buffer));
+  expect(audio).not.toBeNull();
+  expect([...audio!]).toEqual([1, 2, 3, 4]);
+});
+
+test("honours a typed-array view's window into a larger buffer", () => {
+  // A view over the middle of a backing buffer: copying the whole buffer would
+  // send the neighbouring bytes, which is the exact bug this guards against.
+  const backing = new Uint8Array([9, 9, 1, 2, 3, 9]);
+  const view = new Uint8Array(backing.buffer, 2, 3);
+
+  const audio = readAudioFrame(frame(view));
+
+  expect([...audio!]).toEqual([1, 2, 3]);
+});
+
+test("an empty binary frame is an empty buffer, not null", () => {
+  const audio = readAudioFrame(frame(new ArrayBuffer(0)));
+  expect(audio).not.toBeNull();
+  expect(audio!.length).toBe(0);
+});
+
+test("a text frame is not audio", () => {
+  expect(readAudioFrame(frame(JSON.stringify({ type: "stop" })))).toBeNull();
+});
+
+test("recognises the stop control message", () => {
+  expect(isStopMessage(frame(JSON.stringify({ type: "stop" })))).toBe(true);
+});
+
+test("a different control message is not a stop", () => {
+  expect(isStopMessage(frame(JSON.stringify({ type: "start" })))).toBe(false);
+});
+
+test("a binary frame is not a stop message", () => {
+  expect(isStopMessage(frame(new Uint8Array([1, 2, 3]).buffer))).toBe(false);
+});
+
+test("a malformed text frame is not a stop message", () => {
+  expect(isStopMessage(frame("not json{"))).toBe(false);
+});

--- a/apps/backend/src/wsFrame.ts
+++ b/apps/backend/src/wsFrame.ts
@@ -1,0 +1,43 @@
+import type { WSMessageReceive } from "hono/ws";
+
+/**
+ * Decodes the two frame shapes both audio sockets speak.
+ *
+ * `/ws` and `/asr/eval` receive the same wire: PCM as binary frames, control as
+ * JSON text. The decode is fiddly in the same way for both — a binary frame can
+ * arrive as an `ArrayBuffer` or as a typed-array *view* onto a larger buffer,
+ * and the view's `byteOffset`/`byteLength` must be honoured or the wrong bytes
+ * get transcribed. That care is exactly what rots when copied, so it lives here
+ * once (dtinth/vxbeamer#72).
+ *
+ * This module reaches nothing in the message log, so sharing it does not weaken
+ * `evalSocket.ts`'s deliberate isolation from the store: a frame decoder has no
+ * business there and imports none of it.
+ */
+
+/**
+ * Returns the PCM in a binary frame, or `null` if the frame is not binary (a
+ * text control frame). An empty binary frame yields an empty buffer, not
+ * `null` — absence of audio is distinct from "not an audio frame".
+ */
+export function readAudioFrame(data: WSMessageReceive): Buffer | null {
+  if (data instanceof ArrayBuffer) return Buffer.from(data);
+  if (ArrayBuffer.isView(data)) {
+    // Honour the view's window: a typed array can be a slice of a larger buffer,
+    // and copying the whole backing buffer would send neighbouring bytes.
+    return Buffer.from(data.buffer as ArrayBuffer, data.byteOffset, data.byteLength);
+  }
+  return null;
+}
+
+/** Whether a frame is the `{"type":"stop"}` control message. */
+export function isStopMessage(data: WSMessageReceive): boolean {
+  if (typeof data !== "string") return false;
+  try {
+    const message = JSON.parse(data) as { type?: string };
+    return message.type === "stop";
+  } catch {
+    // A text frame that is not JSON is not a stop; ignore it.
+    return false;
+  }
+}

--- a/apps/website/src/backendSocket.ts
+++ b/apps/website/src/backendSocket.ts
@@ -1,0 +1,25 @@
+/**
+ * Builds a `ws(s)://` URL to a backend socket route from the `http(s)` backend
+ * base. Both audio sockets — the recording `/ws` and each eval `/asr/eval` —
+ * derive their URL the same way: swap the scheme to WebSocket, set the path,
+ * drop any inherited query, and attach params.
+ *
+ * `searchParams.set` is not a convenience here, it is the requirement: a
+ * configuration id may contain `+` (`qwen/qwen3-asr-flash-realtime+groq`), and a
+ * hand-built query string would send that `+` literally, which the server
+ * decodes back as a space and then fails to recognise. `set` percent-encodes it.
+ */
+export function buildBackendSocketUrl(
+  backendUrl: string,
+  pathname: string,
+  params: Record<string, string>,
+): string {
+  const url = new URL(backendUrl);
+  url.protocol = url.protocol === "https:" ? "wss:" : "ws:";
+  url.pathname = pathname;
+  url.search = "";
+  for (const [key, value] of Object.entries(params)) {
+    url.searchParams.set(key, value);
+  }
+  return url.toString();
+}

--- a/apps/website/src/components/RecordingBar.tsx
+++ b/apps/website/src/components/RecordingBar.tsx
@@ -10,6 +10,7 @@ import {
   setActiveRecordingReferenceId,
 } from "../store.ts";
 import { type AudioSource, createMicrophoneSource } from "../audio.ts";
+import { buildBackendSocketUrl } from "../backendSocket.ts";
 import { type RecordingRetainer, retainRecording } from "../recordedAudio.ts";
 import { SettingsIcon } from "./SettingsIcon.tsx";
 
@@ -143,14 +144,12 @@ export function RecordingBar({
         }
       });
 
-      const wsUrl = new URL(backendUrl);
-      wsUrl.protocol = wsUrl.protocol === "https:" ? "wss:" : "ws:";
-      wsUrl.pathname = "/ws";
-      wsUrl.search = "";
-      wsUrl.searchParams.set("access_token", authToken);
-      wsUrl.searchParams.set("reference_id", referenceId);
+      const wsUrl = buildBackendSocketUrl(backendUrl, "/ws", {
+        access_token: authToken,
+        reference_id: referenceId,
+      });
 
-      const ws = new WebSocket(wsUrl.toString());
+      const ws = new WebSocket(wsUrl);
       ws.binaryType = "arraybuffer";
       wsRef.current = ws;
       ws.addEventListener("close", () => {

--- a/apps/website/src/evalRun.ts
+++ b/apps/website/src/evalRun.ts
@@ -1,7 +1,8 @@
 import { atom, computed, type ReadableAtom } from "nanostores";
 import type { UsageRecord } from "vxasr";
 import { BYTES_PER_SECOND } from "vxasr/audio";
-import { RETAINED_AUDIO_FORMAT } from "./recordedAudio.ts";
+import { buildBackendSocketUrl } from "./backendSocket.ts";
+import { RETAINED_AUDIO_FORMAT, concatChunks } from "./recordedAudio.ts";
 
 /**
  * An eval run: one retained recording, replayed against every configuration at
@@ -146,15 +147,8 @@ export function toPacedFrames(
   chunks: readonly ArrayBuffer[],
   frameBytes: number = EVAL_FRAME_BYTES,
 ): ArrayBuffer[] {
-  let total = 0;
-  for (const chunk of chunks) total += chunk.byteLength;
-
-  const joined = new Uint8Array(total);
-  let offset = 0;
-  for (const chunk of chunks) {
-    joined.set(new Uint8Array(chunk), offset);
-    offset += chunk.byteLength;
-  }
+  const joined = concatChunks(chunks);
+  const total = joined.byteLength;
 
   const frames: ArrayBuffer[] = [];
   for (let start = 0; start < total; start += frameBytes) {
@@ -175,27 +169,16 @@ export function evalRowCost(row: EvalRow): number {
   return row.usage.reduce((sum, record) => sum + record.unitPrice * record.quantity, 0);
 }
 
-/**
- * Builds the URL for one configuration's eval socket.
- *
- * `URLSearchParams` is not a convenience here, it is the requirement: a
- * configuration id may contain `+` (`qwen/qwen3-asr-flash-realtime+groq`), and
- * a hand-concatenated query string would send that `+` literally, which the
- * server decodes back as a space and then fails to recognise. `set`
- * percent-encodes it.
- */
+/** Builds the URL for one configuration's eval socket. */
 export function buildEvalSocketUrl(options: {
   backendUrl: string;
   accessToken: string;
   configurationId: string;
 }): string {
-  const url = new URL(options.backendUrl);
-  url.protocol = url.protocol === "https:" ? "wss:" : "ws:";
-  url.pathname = "/asr/eval";
-  url.search = "";
-  url.searchParams.set("access_token", options.accessToken);
-  url.searchParams.set("configuration", options.configurationId);
-  return url.toString();
+  return buildBackendSocketUrl(options.backendUrl, "/asr/eval", {
+    access_token: options.accessToken,
+    configuration: options.configurationId,
+  });
 }
 
 /** The real transport: one WebSocket per configuration. */

--- a/apps/website/src/evalUpload.ts
+++ b/apps/website/src/evalUpload.ts
@@ -2,6 +2,7 @@ import type { UsageRecord } from "vxasr";
 import { writeWav } from "vxasr/audio";
 import {
   RETAINED_AUDIO_FORMAT,
+  concatChunks,
   getRetainedRecording,
   retainedDurationSeconds,
   type RetainedRecording,
@@ -173,17 +174,6 @@ export function buildVotePayload(pick: WinnerPick, context: PayloadContext): Vot
     ...(audio ? { audio } : {}),
     savedForEval: pick.saveForEval,
   };
-}
-
-/** Flattens the retained chunks into the contiguous PCM a WAV body needs. */
-function concatChunks(chunks: readonly ArrayBuffer[], byteLength: number): Uint8Array {
-  const pcm = new Uint8Array(byteLength);
-  let offset = 0;
-  for (const chunk of chunks) {
-    pcm.set(new Uint8Array(chunk), offset);
-    offset += chunk.byteLength;
-  }
-  return pcm;
 }
 
 /**

--- a/apps/website/src/recordedAudio.ts
+++ b/apps/website/src/recordedAudio.ts
@@ -90,6 +90,23 @@ export function retainedDurationSeconds(recording: RetainedRecording): number {
   return recording.capturedByteLength / RETAINED_AUDIO_FORMAT.bytesPerSecond;
 }
 
+/**
+ * Flattens retained chunks into one contiguous PCM buffer — what both a WAV
+ * body and an eval replay's frame re-cutting start from. Pass `byteLength` when
+ * it is already known (a `RetainedRecording` carries it); otherwise it is summed
+ * from the chunks.
+ */
+export function concatChunks(chunks: readonly ArrayBuffer[], byteLength?: number): Uint8Array {
+  const total = byteLength ?? chunks.reduce((sum, chunk) => sum + chunk.byteLength, 0);
+  const pcm = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    pcm.set(new Uint8Array(chunk), offset);
+    offset += chunk.byteLength;
+  }
+  return pcm;
+}
+
 /** Total bytes currently held across all retained recordings. */
 export function retainedBytesTotal(): number {
   let total = 0;

--- a/packages/vxasr/src/providers/bufferedSocketSession.ts
+++ b/packages/vxasr/src/providers/bufferedSocketSession.ts
@@ -1,0 +1,134 @@
+import WebSocket from "ws";
+import type { ASRSession } from "../asr.ts";
+
+/**
+ * The wiring every streaming WebSocket provider repeats verbatim.
+ *
+ * Qwen, Qwen-Omni and BytePlus differ in what they say on the wire — URL and
+ * headers, handshake, frame encoding, turn-end, how usage is measured — but the
+ * *plumbing* around those is identical: buffer incoming PCM, flush it in
+ * fixed-size chunks once the socket is open, hold whatever arrives before the
+ * handshake, end the turn once (racing a clip that finished before the socket
+ * did), tear the socket down on `close()`, and hang up on a transport error.
+ * Three copies of that had already drifted apart (dtinth/vxbeamer#72), so it
+ * lives here once.
+ *
+ * What stays with each provider is exactly what is genuinely per-vendor:
+ * {@link BufferedSocketSessionOptions.sendChunk} and {@link
+ * BufferedSocketSessionOptions.endTurn} own the frame encoding and turn-end,
+ * {@link BufferedSocketSessionOptions.sendHandshake} the opening payload, and
+ * {@link BufferedSocketSessionOptions.handleMessage} the parsing. **Byte
+ * accounting is deliberately not here**: a provider that bills per audio-second
+ * counts bytes inside its own `sendChunk`/`endTurn`, and one billed by
+ * vendor-reported tokens simply does not — the helper never assumes a metering
+ * model.
+ */
+export interface BufferedSocketSessionOptions {
+  /** The vendor socket, freshly constructed by the provider. */
+  readonly ws: WebSocket;
+  /** Bytes per flushed chunk. A real vendor requirement, not a preference. */
+  readonly chunkSize: number;
+  /**
+   * Send one chunk, already sliced to exactly {@link chunkSize}. This is where a
+   * per-second-billed provider counts bytes; a token-billed one need not.
+   */
+  sendChunk(chunk: Buffer): void;
+  /** Send the opening handshake. Runs once, the moment the socket opens. */
+  sendHandshake(): void;
+  /**
+   * End the turn: emit the vendor's turn-end for `remaining` — the sub-chunk
+   * tail the flush loop left behind (possibly empty). Runs at most once, and
+   * only while the socket is open. A provider that ends its turn with a final
+   * audio packet sends it here even when `remaining` is empty; one that ends
+   * with a control message appends `remaining` only when there is something to
+   * append.
+   */
+  endTurn(remaining: Buffer): void;
+  /** Parse one server frame. Never invoked after {@link ASRSession.close}. */
+  handleMessage(raw: Buffer): void;
+  /** Report a transport-level socket error (not a vendor error frame). */
+  onError(err: Error): void;
+}
+
+/**
+ * Builds the {@link ASRSession} plumbing shared by the streaming providers. The
+ * caller supplies the per-vendor wire behaviour; this owns buffer/ready state,
+ * the flush loop, the pre-open finish race, and teardown.
+ */
+export function createBufferedSocketSession(options: BufferedSocketSessionOptions): ASRSession {
+  const { ws, chunkSize, sendChunk, sendHandshake, endTurn, handleMessage, onError } = options;
+
+  let buffer = Buffer.alloc(0);
+  let ready = false;
+  let finishing = false;
+  let closed = false;
+
+  function flush() {
+    while (buffer.length >= chunkSize) {
+      const chunk = buffer.subarray(0, chunkSize);
+      buffer = buffer.subarray(chunkSize);
+      sendChunk(chunk);
+    }
+  }
+
+  /** Hand the sub-chunk tail to the provider's turn-end. Open-socket only. */
+  function finishTurn() {
+    const remaining = buffer;
+    buffer = Buffer.alloc(0);
+    endTurn(remaining);
+  }
+
+  ws.on("open", () => {
+    // A `close()` before the handshake means the session was abandoned while
+    // connecting; do not speak into a socket that is being terminated.
+    if (closed) return;
+    sendHandshake();
+    ready = true;
+    flush();
+    // A clip short enough to finish before the socket opened still has to be
+    // sent, or the turn never ends and the session hangs.
+    if (finishing) finishTurn();
+  });
+
+  ws.on("message", (raw: Buffer) => {
+    if (closed) return;
+    handleMessage(raw);
+  });
+
+  ws.on("error", (err: Error) => {
+    if (closed) return;
+    onError(err);
+    // A transport error leaves the socket half-open; close it so its slot in the
+    // vendor's connection pool is released rather than lingering.
+    ws.close();
+  });
+
+  return {
+    sendAudio(chunk: Buffer) {
+      if (finishing) return;
+      buffer = Buffer.concat([buffer, chunk]);
+      if (ready) flush();
+    },
+
+    finish() {
+      if (finishing) return;
+      finishing = true;
+      // End the turn only on a live socket. Not open yet: the `open` handler
+      // ends it once the handshake has gone out. Ready but no longer OPEN (a
+      // post-open error or close): sending would fire a spurious error on a dead
+      // socket — the guard BytePlus always had and the other two silently
+      // lacked, now settled here for all three (#72).
+      if (ready && ws.readyState === WebSocket.OPEN) finishTurn();
+    },
+
+    close() {
+      if (closed) return;
+      closed = true;
+      // Stop feeding and finishing; from here the socket is being torn down, not
+      // wound down. `terminate` releases the connection immediately in any state
+      // (CONNECTING included), which `close()` cannot promise.
+      finishing = true;
+      ws.terminate();
+    },
+  };
+}

--- a/packages/vxasr/src/providers/byteplus.ts
+++ b/packages/vxasr/src/providers/byteplus.ts
@@ -2,6 +2,7 @@ import WebSocket from "ws";
 import { randomUUID } from "crypto";
 import type { ASRProvider, ASRSession, ASRSessionCallbacks } from "../asr.ts";
 import { BYTES_PER_SECOND } from "../audio.ts";
+import { createBufferedSocketSession } from "./bufferedSocketSession.ts";
 
 const BYTEPLUS_PRICE_PER_SECOND = 0.15 / 3600;
 
@@ -133,118 +134,75 @@ export function createBytePlusProvider(config: BytePlusProviderConfig): ASRProvi
         },
       });
 
-      let buffer = Buffer.alloc(0);
-      let ready = false;
-      let finishing = false;
-      let closed = false;
       let totalBytesSent = 0;
 
-      function flushBuffer() {
-        while (buffer.length >= CHUNK_SIZE) {
-          const chunk = buffer.subarray(0, CHUNK_SIZE);
-          buffer = buffer.subarray(CHUNK_SIZE);
+      return createBufferedSocketSession({
+        ws,
+        chunkSize: CHUNK_SIZE,
+        sendChunk(chunk) {
           totalBytesSent += chunk.length;
           ws.send(buildAudioPacket(chunk, false));
-        }
-      }
-
-      /** Sends whatever is left as the last packet, which ends the turn. */
-      function sendLastPacket() {
-        totalBytesSent += buffer.length;
-        ws.send(buildAudioPacket(buffer, true));
-        buffer = Buffer.alloc(0);
-      }
-
-      ws.on("open", () => {
-        ws.send(
-          buildFullClientRequest({
-            user: { uid: "cli-user" },
-            audio: {
-              format: "pcm",
-              codec: "raw",
-              rate: 16000,
-              bits: 16,
-              channel: 1,
-              // `language` belongs to the audio object, not the request object,
-              // and only where the mode declares it — the vendor documents it as
-              // unsupported on bi-directional streaming.
-              ...(mode.supportsLanguage && config.language ? { language: config.language } : {}),
-            },
-            request: {
-              model_name: mode.modelName,
-              enable_itn: true,
-              enable_punc: true,
-            },
-          }),
-        );
-        ready = true;
-        flushBuffer();
-        // A clip short enough to finish before the socket opened still has to be
-        // sent; otherwise the turn never ends and the session hangs.
-        if (finishing) sendLastPacket();
-      });
-
-      ws.on("message", (raw: Buffer) => {
-        if (closed) return;
-        const { isLast, text, error } = parseServerMessage(raw as Buffer);
-
-        if (error) {
-          callbacks.onError?.(new Error(error));
-          ws.close();
-          return;
-        }
-
-        if (isLast) {
-          if (text.trim()) callbacks.onFinal?.(text);
-          const seconds = Math.ceil(totalBytesSent / BYTES_PER_SECOND);
-          callbacks.onUsage?.([
-            {
-              sku: "byteplus:seedasr:seconds",
-              unitPrice: BYTEPLUS_PRICE_PER_SECOND,
-              quantity: seconds,
-            },
-          ]);
-          callbacks.onEnd?.();
-          ws.close(1000, "done");
-        } else if (text) {
-          callbacks.onPartial?.(text);
-        }
-      });
-
-      ws.on("error", (err: Error) => {
-        if (closed) return;
-        callbacks.onError?.(err);
-        // A transport error leaves the socket half-open; close it so its slot in
-        // the vendor's connection pool is released rather than lingering.
-        ws.close();
-      });
-
-      return {
-        sendAudio(chunk: Buffer) {
-          if (finishing) return;
-          buffer = Buffer.concat([buffer, chunk]);
-          if (ready) flushBuffer();
         },
-
-        finish() {
-          if (finishing) return;
-          finishing = true;
-          // Not open yet: the `open` handler sends the last packet instead, once
-          // the handshake it must follow has gone out.
-          if (!ready || ws.readyState !== WebSocket.OPEN) return;
-          sendLastPacket();
+        sendHandshake() {
+          ws.send(
+            buildFullClientRequest({
+              user: { uid: "cli-user" },
+              audio: {
+                format: "pcm",
+                codec: "raw",
+                rate: 16000,
+                bits: 16,
+                channel: 1,
+                // `language` belongs to the audio object, not the request
+                // object, and only where the mode declares it — the vendor
+                // documents it as unsupported on bi-directional streaming.
+                ...(mode.supportsLanguage && config.language
+                  ? { language: config.language }
+                  : {}),
+              },
+              request: {
+                model_name: mode.modelName,
+                enable_itn: true,
+                enable_punc: true,
+              },
+            }),
+          );
         },
-
-        close() {
-          if (closed) return;
-          closed = true;
-          // Stop feeding and finishing; from here the socket is being torn down,
-          // not wound down. `terminate` releases the connection immediately in
-          // any state (CONNECTING included), which `close()` cannot promise.
-          finishing = true;
-          ws.terminate();
+        // BytePlus ends the turn with a final audio packet, so this is sent even
+        // when `remaining` is empty: the `isLast` flag is what closes the turn.
+        endTurn(remaining) {
+          totalBytesSent += remaining.length;
+          ws.send(buildAudioPacket(remaining, true));
         },
-      };
+        handleMessage(raw) {
+          const { isLast, text, error } = parseServerMessage(raw);
+
+          if (error) {
+            callbacks.onError?.(new Error(error));
+            ws.close();
+            return;
+          }
+
+          if (isLast) {
+            if (text.trim()) callbacks.onFinal?.(text);
+            const seconds = Math.ceil(totalBytesSent / BYTES_PER_SECOND);
+            callbacks.onUsage?.([
+              {
+                sku: "byteplus:seedasr:seconds",
+                unitPrice: BYTEPLUS_PRICE_PER_SECOND,
+                quantity: seconds,
+              },
+            ]);
+            callbacks.onEnd?.();
+            ws.close(1000, "done");
+          } else if (text) {
+            callbacks.onPartial?.(text);
+          }
+        },
+        onError(err) {
+          callbacks.onError?.(err);
+        },
+      });
     },
   };
 }

--- a/packages/vxasr/src/providers/byteplus.ts
+++ b/packages/vxasr/src/providers/byteplus.ts
@@ -156,9 +156,7 @@ export function createBytePlusProvider(config: BytePlusProviderConfig): ASRProvi
                 // `language` belongs to the audio object, not the request
                 // object, and only where the mode declares it — the vendor
                 // documents it as unsupported on bi-directional streaming.
-                ...(mode.supportsLanguage && config.language
-                  ? { language: config.language }
-                  : {}),
+                ...(mode.supportsLanguage && config.language ? { language: config.language } : {}),
               },
               request: {
                 model_name: mode.modelName,

--- a/packages/vxasr/src/providers/qwen-omni.ts
+++ b/packages/vxasr/src/providers/qwen-omni.ts
@@ -1,5 +1,6 @@
 import WebSocket from "ws";
 import type { ASRProvider, ASRSession, ASRSessionCallbacks, UsageRecord } from "../asr.ts";
+import { createBufferedSocketSession } from "./bufferedSocketSession.ts";
 
 /**
  * The Qwen **Omni Realtime** models, which are not ASR models at all: they are
@@ -171,21 +172,9 @@ export function createQwenOmniProvider(config: QwenOmniProviderConfig): ASRProvi
         },
       });
 
-      let buffer = Buffer.alloc(0);
-      let ready = false;
-      let finishing = false;
-      let closed = false;
       let transcript = "";
 
-      function flushBuffer() {
-        while (buffer.length >= CHUNK_SIZE) {
-          const chunk = buffer.subarray(0, CHUNK_SIZE);
-          buffer = buffer.subarray(CHUNK_SIZE);
-          append(chunk);
-        }
-      }
-
-      function append(audio: Buffer) {
+      const append = (audio: Buffer) =>
         ws.send(
           JSON.stringify({
             event_id: `event_${Date.now()}`,
@@ -193,114 +182,78 @@ export function createQwenOmniProvider(config: QwenOmniProviderConfig): ASRProvi
             audio: audio.toString("base64"),
           }),
         );
-      }
 
-      /**
-       * Ends the turn. Unlike the ASR protocol, committing the buffer only
-       * closes the *input*: the model does nothing until `response.create` asks
-       * it for one. There is no `session.finish` here.
-       */
-      function doFinish() {
-        if (buffer.length > 0) {
-          append(buffer);
-          buffer = Buffer.alloc(0);
-        }
-        ws.send(JSON.stringify({ event_id: "event_commit", type: "input_audio_buffer.commit" }));
-        ws.send(JSON.stringify({ event_id: "event_response", type: "response.create" }));
-      }
-
-      ws.on("open", () => {
-        ws.send(
-          JSON.stringify({
-            event_id: "event_session",
-            type: "session.update",
-            session: {
-              modalities: ["text"],
-              // `pcm`, not the `pcm16` the OpenAI realtime protocol names.
-              input_audio_format: "pcm",
-              sample_rate: 16000,
-              // Manual turn-taking: the recording decides when the turn ends,
-              // not a silence detector.
-              turn_detection: null,
-              instructions: QWEN_OMNI_TRANSCRIPTION_INSTRUCTIONS,
-              // Silences the transcription sub-service. This field names a
-              // *separate* ASR model that runs alongside and transcribes our
-              // audio independently — it is not this model, and its output
-              // differs (it renders `project` in Latin where the omni model
-              // renders `โปรเจกต์` in Thai). Naming no model turns it off
-              // entirely: with the field omitted the vendor picks one and
-              // streams events we would only ignore, for a second model's worth
-              // of audio we never asked to be heard by. Verified: `{}` yields
-              // zero `conversation.item.input_audio_transcription.*` events.
-              input_audio_transcription: {},
-            },
-          }),
-        );
-        ready = true;
-        flushBuffer();
-        // A clip short enough to finish before the socket opened still has to
-        // be sent, or no response is ever requested and the session hangs.
-        if (finishing) doFinish();
-      });
-
-      ws.on("message", (raw: Buffer) => {
-        if (closed) return;
-        const data = JSON.parse(raw.toString());
-
-        if (data.type === "response.text.delta") {
-          // Deltas are incremental, so the running text is what a partial is.
-          transcript += data.delta ?? "";
-          callbacks.onPartial?.(transcript);
-        } else if (data.type === "response.text.done") {
-          transcript = data.text ?? transcript;
-          callbacks.onFinal?.(transcript);
-        } else if (data.type === "response.done") {
-          // Usage lands here, after the text — so this, not `response.text.done`,
-          // is where a session ends.
-          callbacks.onUsage?.(buildUsageRecords(model, pricing, data.response?.usage));
-          callbacks.onEnd?.();
-          ws.close(1000, "done");
-        } else if (data.type === "error") {
-          callbacks.onError?.(new Error(JSON.stringify(data)));
-          // The turn is over and will produce nothing, so hang up rather than
-          // hold the socket open. A session that has errored still counts
-          // against the vendor's 120-minute session cap until it closes.
-          ws.close();
-        }
-      });
-
-      ws.on("error", (err: Error) => {
-        if (closed) return;
-        callbacks.onError?.(err);
-        // A transport error leaves the socket half-open; close it so its slot in
-        // the vendor's connection pool is released rather than lingering.
-        ws.close();
-      });
-
-      return {
-        sendAudio(chunk: Buffer) {
-          if (finishing) return;
-          buffer = Buffer.concat([buffer, chunk]);
-          if (ready) flushBuffer();
+      return createBufferedSocketSession({
+        ws,
+        chunkSize: CHUNK_SIZE,
+        // Token-billed, so no byte accounting here — usage comes from the
+        // vendor's own `response.done` report.
+        sendChunk: append,
+        sendHandshake() {
+          ws.send(
+            JSON.stringify({
+              event_id: "event_session",
+              type: "session.update",
+              session: {
+                modalities: ["text"],
+                // `pcm`, not the `pcm16` the OpenAI realtime protocol names.
+                input_audio_format: "pcm",
+                sample_rate: 16000,
+                // Manual turn-taking: the recording decides when the turn ends,
+                // not a silence detector.
+                turn_detection: null,
+                instructions: QWEN_OMNI_TRANSCRIPTION_INSTRUCTIONS,
+                // Silences the transcription sub-service. This field names a
+                // *separate* ASR model that runs alongside and transcribes our
+                // audio independently — it is not this model, and its output
+                // differs (it renders `project` in Latin where the omni model
+                // renders `โปรเจกต์` in Thai). Naming no model turns it off
+                // entirely: with the field omitted the vendor picks one and
+                // streams events we would only ignore, for a second model's
+                // worth of audio we never asked to be heard by. Verified: `{}`
+                // yields zero `conversation.item.input_audio_transcription.*`
+                // events.
+                input_audio_transcription: {},
+              },
+            }),
+          );
         },
-
-        finish() {
-          if (finishing) return;
-          finishing = true;
-          if (ready) doFinish();
-          // else: the `open` handler calls doFinish() once the session is set up.
+        // Ends the turn. Unlike the ASR protocol, committing the buffer only
+        // closes the *input*: the model does nothing until `response.create`
+        // asks it for one. There is no `session.finish` here.
+        endTurn(remaining) {
+          if (remaining.length > 0) append(remaining);
+          ws.send(JSON.stringify({ event_id: "event_commit", type: "input_audio_buffer.commit" }));
+          ws.send(JSON.stringify({ event_id: "event_response", type: "response.create" }));
         },
+        handleMessage(raw) {
+          const data = JSON.parse(raw.toString());
 
-        close() {
-          if (closed) return;
-          closed = true;
-          // Stop feeding and finishing; from here the socket is being torn down,
-          // not wound down. `terminate` releases the connection immediately in
-          // any state (CONNECTING included), which `close()` cannot promise.
-          finishing = true;
-          ws.terminate();
+          if (data.type === "response.text.delta") {
+            // Deltas are incremental, so the running text is what a partial is.
+            transcript += data.delta ?? "";
+            callbacks.onPartial?.(transcript);
+          } else if (data.type === "response.text.done") {
+            transcript = data.text ?? transcript;
+            callbacks.onFinal?.(transcript);
+          } else if (data.type === "response.done") {
+            // Usage lands here, after the text — so this, not
+            // `response.text.done`, is where a session ends.
+            callbacks.onUsage?.(buildUsageRecords(model, pricing, data.response?.usage));
+            callbacks.onEnd?.();
+            ws.close(1000, "done");
+          } else if (data.type === "error") {
+            callbacks.onError?.(new Error(JSON.stringify(data)));
+            // The turn is over and will produce nothing, so hang up rather than
+            // hold the socket open. A session that has errored still counts
+            // against the vendor's 120-minute session cap until it closes.
+            ws.close();
+          }
         },
-      };
+        onError(err) {
+          callbacks.onError?.(err);
+        },
+      });
     },
   };
 }

--- a/packages/vxasr/src/providers/qwen.ts
+++ b/packages/vxasr/src/providers/qwen.ts
@@ -1,6 +1,7 @@
 import WebSocket from "ws";
 import type { ASRProvider, ASRSession, ASRSessionCallbacks } from "../asr.ts";
 import { BYTES_PER_SECOND } from "../audio.ts";
+import { createBufferedSocketSession } from "./bufferedSocketSession.ts";
 
 const QWEN_PRICE_PER_SECOND = 0.000035;
 
@@ -23,124 +24,79 @@ export function createQwenProvider(config: QwenProviderConfig): ASRProvider {
         },
       });
 
-      let buffer = Buffer.alloc(0);
-      let ready = false;
-      let finishing = false;
-      let closed = false;
       let totalBytesSent = 0;
 
-      function flushBuffer() {
-        while (buffer.length >= CHUNK_SIZE) {
-          const chunk = buffer.subarray(0, CHUNK_SIZE);
-          buffer = buffer.subarray(CHUNK_SIZE);
-          totalBytesSent += chunk.length;
-          ws.send(
-            JSON.stringify({
-              event_id: `event_${Date.now()}`,
-              type: "input_audio_buffer.append",
-              audio: chunk.toString("base64"),
-            }),
-          );
-        }
-      }
-
-      function doFinish() {
-        if (buffer.length > 0) {
-          totalBytesSent += buffer.length;
-          ws.send(
-            JSON.stringify({
-              event_id: `event_${Date.now()}`,
-              type: "input_audio_buffer.append",
-              audio: buffer.toString("base64"),
-            }),
-          );
-          buffer = Buffer.alloc(0);
-        }
-        ws.send(JSON.stringify({ event_id: "event_commit", type: "input_audio_buffer.commit" }));
-        ws.send(JSON.stringify({ event_id: "event_finish", type: "session.finish" }));
-      }
-
-      ws.on("open", () => {
+      const appendFrame = (audio: Buffer) =>
         ws.send(
           JSON.stringify({
-            event_id: "event_session",
-            type: "session.update",
-            session: {
-              modalities: ["text"],
-              input_audio_format: "pcm",
-              sample_rate: 16000,
-              input_audio_transcription: {},
-              turn_detection: null,
-            },
+            event_id: `event_${Date.now()}`,
+            type: "input_audio_buffer.append",
+            audio: audio.toString("base64"),
           }),
         );
-        ready = true;
-        flushBuffer();
-        if (finishing) doFinish();
-      });
 
-      ws.on("message", (raw: Buffer) => {
-        if (closed) return;
-        const data = JSON.parse(raw.toString());
-
-        if (data.type === "conversation.item.input_audio_transcription.text") {
-          callbacks.onPartial?.(data.text ?? "");
-        } else if (data.type === "conversation.item.input_audio_transcription.completed") {
-          callbacks.onFinal?.(data.transcript ?? "");
-        } else if (data.type === "session.finished") {
-          const seconds = Math.ceil(totalBytesSent / BYTES_PER_SECOND);
-          callbacks.onUsage?.([
-            {
-              sku: "dashscope:qwen3-asr-flash:seconds",
-              unitPrice: QWEN_PRICE_PER_SECOND,
-              quantity: seconds,
-            },
-          ]);
-          callbacks.onEnd?.();
-          ws.close(1000, "done");
-        } else if (data.type === "error") {
-          callbacks.onError?.(new Error(JSON.stringify(data)));
-          // The turn is over and will produce nothing, so hang up rather than
-          // hold the socket open. An errored session still counts against the
-          // vendor's connection cap until it closes — and "connections too much"
-          // is itself one of these error frames, so leaking here compounds the
-          // very condition it reports.
-          ws.close();
-        }
-      });
-
-      ws.on("error", (err: Error) => {
-        if (closed) return;
-        callbacks.onError?.(err);
-        // A transport error leaves the socket half-open; close it so its slot in
-        // the vendor's connection pool is released rather than lingering.
-        ws.close();
-      });
-
-      return {
-        sendAudio(chunk: Buffer) {
-          if (finishing) return;
-          buffer = Buffer.concat([buffer, chunk]);
-          if (ready) flushBuffer();
+      return createBufferedSocketSession({
+        ws,
+        chunkSize: CHUNK_SIZE,
+        sendChunk(chunk) {
+          totalBytesSent += chunk.length;
+          appendFrame(chunk);
         },
-
-        finish() {
-          if (finishing) return;
-          finishing = true;
-          if (ready) doFinish();
-          // else: doFinish() will be called from the 'open' handler
+        sendHandshake() {
+          ws.send(
+            JSON.stringify({
+              event_id: "event_session",
+              type: "session.update",
+              session: {
+                modalities: ["text"],
+                input_audio_format: "pcm",
+                sample_rate: 16000,
+                input_audio_transcription: {},
+                turn_detection: null,
+              },
+            }),
+          );
         },
-
-        close() {
-          if (closed) return;
-          closed = true;
-          // Stop feeding and finishing; from here the socket is being torn down,
-          // not wound down. `terminate` releases the connection immediately in
-          // any state (CONNECTING included), which `close()` cannot promise.
-          finishing = true;
-          ws.terminate();
+        endTurn(remaining) {
+          if (remaining.length > 0) {
+            totalBytesSent += remaining.length;
+            appendFrame(remaining);
+          }
+          ws.send(JSON.stringify({ event_id: "event_commit", type: "input_audio_buffer.commit" }));
+          ws.send(JSON.stringify({ event_id: "event_finish", type: "session.finish" }));
         },
-      };
+        handleMessage(raw) {
+          const data = JSON.parse(raw.toString());
+
+          if (data.type === "conversation.item.input_audio_transcription.text") {
+            callbacks.onPartial?.(data.text ?? "");
+          } else if (data.type === "conversation.item.input_audio_transcription.completed") {
+            callbacks.onFinal?.(data.transcript ?? "");
+          } else if (data.type === "session.finished") {
+            const seconds = Math.ceil(totalBytesSent / BYTES_PER_SECOND);
+            callbacks.onUsage?.([
+              {
+                sku: "dashscope:qwen3-asr-flash:seconds",
+                unitPrice: QWEN_PRICE_PER_SECOND,
+                quantity: seconds,
+              },
+            ]);
+            callbacks.onEnd?.();
+            ws.close(1000, "done");
+          } else if (data.type === "error") {
+            callbacks.onError?.(new Error(JSON.stringify(data)));
+            // The turn is over and will produce nothing, so hang up rather than
+            // hold the socket open. An errored session still counts against the
+            // vendor's connection cap until it closes — and "connections too
+            // much" is itself one of these error frames, so leaking here
+            // compounds the very condition it reports.
+            ws.close();
+          }
+        },
+        onError(err) {
+          callbacks.onError?.(err);
+        },
+      });
     },
   };
 }


### PR DESCRIPTION
Closes #72. Follow-up to #81 (the connection-cleanup work), which — as noted there — added `close()` and the error-close as a fourth verbatim block to the very state machine #72 targets. This collapses it.

## The state machine

Qwen, Qwen-Omni and BytePlus each carried ~35 lines of identical session plumbing: `buffer`/`ready`/`finishing`/`closed` state, the chunk-flush loop, the open-handler tail with its pre-open-finish race, the error handler, and `sendAudio`/`finish`/`close`. Three copies, and they had drifted.

`createBufferedSocketSession` (`packages/vxasr/src/providers/bufferedSocketSession.ts`) owns all of it. Each provider supplies only what is genuinely per-vendor via callbacks:

- `sendHandshake()` — the opening payload
- `sendChunk(chunk)` — frame encoding (base64-in-JSON vs binary length-prefixed packet)
- `endTurn(remaining)` — turn-end (`commit`+`session.finish` vs `commit`+`response.create` vs a last-packet flag)
- `handleMessage(raw)` — parsing and event names

**Byte accounting stays in the provider.** Qwen and BytePlus count `totalBytesSent` inside their own `sendChunk`/`endTurn` because they bill per audio-second; Qwen-Omni doesn't, because it's billed on vendor-reported tokens. The helper never assumes a metering model — the nuance #72 called out.

### The `finish()` drift, settled

BytePlus guarded its turn-end with `ws.readyState === OPEN`; Qwen and Qwen-Omni checked only `ready`. Since neither cleared `ready` on a socket error, finishing those two after a post-open error called `send()` on a dead socket — which `ws` turns into a spurious `onError` that BytePlus stayed quiet about. The guard now lives in the helper's `finish()` and applies to all three.

## Smaller copies folded in (no behaviour change)

- **`readAudioFrame` / `isStopMessage`** (`apps/backend/src/wsFrame.ts`) — the binary-frame decode (including the `byteOffset`/`byteLength` windowing that rots in a copy) and the `stop`-message parse, shared by `/ws` and `/asr/eval`. The decoder imports nothing from the store, so the eval socket's deliberate isolation from the message log is preserved.
- **`buildBackendSocketUrl`** (`apps/website/src/backendSocket.ts`) — the `http(s)`→`ws(s)` URL build shared by the recording bar and the eval fan-out. `searchParams.set` (the `+`-in-configuration-id encoding) is preserved.
- **`concatChunks`** (`recordedAudio.ts`) — the retained-chunk flatten shared by the WAV writer (`evalUpload.ts`) and the eval frame re-cutter (`toPacedFrames`).

## Tests

- `wsFrame.test.ts` — new: ArrayBuffer and typed-array-view decoding (including a non-zero `byteOffset` window), empty-frame vs text-frame, and stop-message recognition.
- The existing `byteplus.test.ts` and `qwen-omni.test.ts` drive the extracted helper end-to-end against fake vendors (open, audio, finish, pre-open-finish, error); `evalRun.test.ts` covers `toPacedFrames` and `buildEvalSocketUrl`, whose public signatures are unchanged.

## Caveat

Same as #81: the sandbox denied `vp install`, so `vp check` / `vp test` were not run here — verified by manual review against the existing wire-level tests. CI covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TiGhRR7pPJgqZLeDSfXYNs

---
_Generated by [Claude Code](https://claude.ai/code/session_01TiGhRR7pPJgqZLeDSfXYNs)_